### PR TITLE
Fixed binary compatibility issues between different MPS versions

### DIFF
--- a/.github/workflows/binary-compatibility.yaml
+++ b/.github/workflows/binary-compatibility.yaml
@@ -1,0 +1,28 @@
+name: Binary Compatibility
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request: {}
+  # allow manual execution just in case
+  workflow_dispatch:
+
+jobs:
+  checkBinaryCompatibility:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./check-binary-compatibility.sh

--- a/check-binary-compatibility.sh
+++ b/check-binary-compatibility.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+set -x
+
+./gradlew :mps-legacy-sync-plugin:jar -Pmps.version=2021.1.4
+VERSION=$(cat version.txt)
+mkdir -p mps-legacy-sync-plugin/build/binary-compatibility
+cp "mps-legacy-sync-plugin/build/libs/mps-legacy-sync-plugin-$VERSION.jar" "mps-legacy-sync-plugin/build/binary-compatibility/a.jar"
+./gradlew :mps-legacy-sync-plugin:jar -Pmps.version=2023.2
+cp "mps-legacy-sync-plugin/build/libs/mps-legacy-sync-plugin-$VERSION.jar" "mps-legacy-sync-plugin/build/binary-compatibility/b.jar"
+./gradlew :mps-legacy-sync-plugin:checkBinaryCompatibility

--- a/check-binary-compatibility.sh
+++ b/check-binary-compatibility.sh
@@ -3,10 +3,10 @@
 set -e
 set -x
 
-./gradlew :mps-legacy-sync-plugin:jar -Pmps.version=2021.1.4
+mkdir -p build/binary-compatibility/mps-legacy-sync-plugin
+./gradlew :mps-legacy-sync-plugin:clean :mps-legacy-sync-plugin:jar -Pmps.version=2021.1.4
 VERSION=$(cat version.txt)
-mkdir -p mps-legacy-sync-plugin/build/binary-compatibility
-cp "mps-legacy-sync-plugin/build/libs/mps-legacy-sync-plugin-$VERSION.jar" "mps-legacy-sync-plugin/build/binary-compatibility/a.jar"
-./gradlew :mps-legacy-sync-plugin:jar -Pmps.version=2023.2
-cp "mps-legacy-sync-plugin/build/libs/mps-legacy-sync-plugin-$VERSION.jar" "mps-legacy-sync-plugin/build/binary-compatibility/b.jar"
+cp "mps-legacy-sync-plugin/build/libs/mps-legacy-sync-plugin-$VERSION.jar" "build/binary-compatibility/mps-legacy-sync-plugin/a.jar"
+./gradlew :mps-legacy-sync-plugin:clean :mps-legacy-sync-plugin:jar -Pmps.version=2023.2
+cp "mps-legacy-sync-plugin/build/libs/mps-legacy-sync-plugin-$VERSION.jar" "build/binary-compatibility/mps-legacy-sync-plugin/b.jar"
 ./gradlew :mps-legacy-sync-plugin:checkBinaryCompatibility

--- a/mps-legacy-sync-plugin/build.gradle.kts
+++ b/mps-legacy-sync-plugin/build.gradle.kts
@@ -18,6 +18,19 @@ java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(11))
     }
+    withSourcesJar()
+}
+
+tasks.compileJava {
+    options.release = 11
+}
+
+tasks.compileKotlin {
+    kotlinOptions {
+        jvmTarget = "11"
+        freeCompilerArgs += listOf("-Xjvm-default=all-compatibility")
+        apiVersion = "1.6"
+    }
 }
 
 kotlin {

--- a/mps-legacy-sync-plugin/build.gradle.kts
+++ b/mps-legacy-sync-plugin/build.gradle.kts
@@ -116,7 +116,10 @@ tasks {
     val checkBinaryCompatibility by registering {
         group = "verification"
         doLast {
-            val ignoredFiles = setOf("META-INF/MANIFEST.MF")
+            val ignoredFiles = setOf(
+                "META-INF/MANIFEST.MF",
+                "org/modelix/model/mpsplugin/AllowedBinaryIncompatibilityKt.class"
+            )
             fun loadEntries(fileName: String) = rootProject.layout.buildDirectory
                 .dir("binary-compatibility")
                 .dir(project.name)

--- a/mps-legacy-sync-plugin/build.gradle.kts
+++ b/mps-legacy-sync-plugin/build.gradle.kts
@@ -1,5 +1,7 @@
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import org.jetbrains.intellij.tasks.PrepareSandboxTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.util.zip.ZipInputStream
 
 plugins {
     id("org.jetbrains.kotlin.jvm")
@@ -109,6 +111,24 @@ tasks {
     withType<PrepareSandboxTask> {
         intoChild(pluginName.map { "$it/languages" })
             .from(project.layout.projectDirectory.dir("repositoryconcepts"))
+    }
+
+    val checkBinaryCompatibility by registering {
+        group = "verification"
+        doLast {
+            val ignoredFiles = setOf("META-INF/MANIFEST.MF")
+            fun loadEntries(fileName: String) = project.layout.buildDirectory.file("binary-compatibility/$fileName").get().asFile.inputStream().use {
+                val zip = ZipInputStream(it)
+                val entries = generateSequence { zip.nextEntry }
+                entries.associate { it.name to "size:${it.size},crc:${it.crc}" }
+            } - ignoredFiles
+            val entriesA = loadEntries("a.jar")
+            val entriesB = loadEntries("b.jar")
+            val mismatches = (entriesA.keys + entriesB.keys).map { it to (entriesA[it] to entriesB[it]) }.filter { it.second.first != it.second.second }
+            check(mismatches.isEmpty()) {
+                "The following files have a different content:\n" + mismatches.joinToString("\n") { "  ${it.first}: ${it.second.first} != ${it.second.second}" }
+            }
+        }
     }
 }
 

--- a/mps-legacy-sync-plugin/build.gradle.kts
+++ b/mps-legacy-sync-plugin/build.gradle.kts
@@ -15,6 +15,9 @@ val mpsHome = rootProject.layout.buildDirectory.dir("mps-$mpsVersion")
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
 }
 
 kotlin {
@@ -68,22 +71,6 @@ intellij {
 }
 
 tasks {
-    // This plugin in intended to be used by all 'supported' MPS versions, as a result we need to use the lowest
-    // common java version, which is JAVA 11 to ensure bytecode compatibility.
-    // However, when building with MPS >= 2022.3 to ensure compileOnly dependency compatibility, we need to build
-    // with JAVA 17 explicitly.
-    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        if (mpsVersion >= "2022.2") {
-            kotlinOptions.jvmTarget = "17"
-            java.sourceCompatibility = JavaVersion.VERSION_17
-            java.targetCompatibility = JavaVersion.VERSION_17
-        } else {
-            kotlinOptions.jvmTarget = "11"
-            java.sourceCompatibility = JavaVersion.VERSION_11
-            java.targetCompatibility = JavaVersion.VERSION_11
-        }
-    }
-
     patchPluginXml {
         sinceBuild.set("211") // 203 not supported, because VersionFixer was replaced by ModuleDependencyVersions in 211
         untilBuild.set("232.10072.781")

--- a/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/AllowedBinaryIncompatibility.kt
+++ b/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/AllowedBinaryIncompatibility.kt
@@ -1,0 +1,16 @@
+package org.modelix.model.mpsplugin
+
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.ProjectManagerListener
+import com.intellij.util.messages.MessageBus
+import com.intellij.util.messages.MessageBusConnection
+import com.intellij.util.messages.Topic
+
+/**
+ * This file contains all API calls that lead to a difference in the compiled bytecode.
+ * This class file is ignored during the binary compatibility check.
+ * This file should contain as little code as possible.
+ */
+
+internal fun MessageBus.connectToMessageBus(): MessageBusConnection = connect()
+internal fun getProjectManagerTopic(): Topic<ProjectManagerListener> = ProjectManager.TOPIC

--- a/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/ModelServerConnection.kt
+++ b/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/ModelServerConnection.kt
@@ -72,9 +72,9 @@ class ModelServerConnection @JvmOverloads constructor(baseUrl: String, providedH
         if (LOG.isDebugEnabled) {
             LOG.debug("ModelServerConnection.init(" + baseUrl + ")")
         }
-        messageBusConnection = ApplicationManager.getApplication().messageBus.connect()
+        messageBusConnection = ApplicationManager.getApplication().messageBus.connectToMessageBus()
         messageBusConnection.subscribe(
-            ProjectManager.TOPIC,
+            getProjectManagerTopic(),
             object : ProjectManagerListener {
                 override fun projectClosing(closingProject: Project) {
                     for (closingProjectBinding: ProjectBinding? in Sequence.fromIterable(MapSequence.fromMap(bindings).values)

--- a/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/history/CloudView.kt
+++ b/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/history/CloudView.kt
@@ -41,27 +41,27 @@ class CloudView : JPanel(BorderLayout()) {
         override fun createPopupActionGroup(node: MPSTreeNode): ActionGroup? {
             if (node is CloudRootTreeNode) {
                 return ActionManager.getInstance()
-                    .getAction("org.modelix.model.mpsplugin.plugin.CloudRootGroup_ActionGroup") as ActionGroup
+                    .getAction(org.modelix.model.mpsplugin.plugin.CloudRootGroup_ActionGroup.ID) as ActionGroup
             }
             if (node is ModelServerTreeNode) {
                 return ActionManager.getInstance()
-                    .getAction("org.modelix.model.mpsplugin.plugin.ModelServerGroup_ActionGroup") as ActionGroup
+                    .getAction(org.modelix.model.mpsplugin.plugin.ModelServerGroup_ActionGroup.ID) as ActionGroup
             }
             if (node is CloudNodeTreeNode) {
                 return ActionManager.getInstance()
-                    .getAction("org.modelix.model.mpsplugin.plugin.CloudNodeGroup_ActionGroup") as ActionGroup
+                    .getAction(org.modelix.model.mpsplugin.plugin.CloudNodeGroup_ActionGroup.ID) as ActionGroup
             }
             if (node is RepositoryTreeNode) {
                 return ActionManager.getInstance()
-                    .getAction("org.modelix.model.mpsplugin.plugin.RepositoryGroup_ActionGroup") as ActionGroup
+                    .getAction(org.modelix.model.mpsplugin.plugin.RepositoryGroup_ActionGroup.ID) as ActionGroup
             }
             if (node is CloudBranchTreeNode) {
                 return ActionManager.getInstance()
-                    .getAction("org.modelix.model.mpsplugin.plugin.CloudBranchGroup_ActionGroup") as ActionGroup
+                    .getAction(org.modelix.model.mpsplugin.plugin.CloudBranchGroup_ActionGroup.ID) as ActionGroup
             }
             if (node is CloudBindingTreeNode) {
                 return ActionManager.getInstance()
-                    .getAction("org.modelix.model.mpsplugin.plugin.CloudBindingGroup_ActionGroup") as ActionGroup
+                    .getAction(org.modelix.model.mpsplugin.plugin.CloudBindingGroup_ActionGroup.ID) as ActionGroup
             }
             return null
         }

--- a/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/history/LoadingIcon.kt
+++ b/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/history/LoadingIcon.kt
@@ -49,7 +49,7 @@ class LoadingIcon : Icon {
                         }
                         for (c: MPSTree in SetSequence.fromSet(activeNodes)
                             .select(object : ISelector<MPSTreeNode, MPSTree>() {
-                                override fun select(it: MPSTreeNode): MPSTree {
+                                override fun select(it: MPSTreeNode): MPSTree? {
                                     return it.tree
                                 }
                             }).filterNotNull().distinct()) {

--- a/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/plugin/CloudActionsForPhysicalModules_ActionGroup.kt
+++ b/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/plugin/CloudActionsForPhysicalModules_ActionGroup.kt
@@ -1,7 +1,7 @@
 package org.modelix.model.mpsplugin.plugin
 
+import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import com.intellij.openapi.extensions.PluginId
 import jetbrains.mps.plugins.actions.GeneratedActionGroup
 import jetbrains.mps.workbench.action.ApplicationPlugin
@@ -15,7 +15,7 @@ class CloudActionsForPhysicalModules_ActionGroup(plugin: ApplicationPlugin) :
         run({
             val newAction: GeneratedActionGroup =
                 CloudActionsForPhysicalModulesCloudActions_ActionGroup(applicationPlugin)
-            val manager: ActionManagerEx = ActionManagerEx.getInstanceEx()
+            val manager: ActionManager = ActionManager.getInstance()
             var oldAction: AnAction? = manager.getAction(newAction.id)
             if (oldAction == null) {
                 manager.registerAction(newAction.id, newAction, PluginId.getId("org.modelix.model.mpsplugin"))

--- a/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/plugin/CloudActionsForPhysicalProjects_ActionGroup.kt
+++ b/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/plugin/CloudActionsForPhysicalProjects_ActionGroup.kt
@@ -1,7 +1,7 @@
 package org.modelix.model.mpsplugin.plugin
 
+import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import com.intellij.openapi.extensions.PluginId
 import jetbrains.mps.plugins.actions.GeneratedActionGroup
 import jetbrains.mps.workbench.action.ApplicationPlugin
@@ -15,7 +15,7 @@ class CloudActionsForPhysicalProjects_ActionGroup(plugin: ApplicationPlugin) :
         run({
             val newAction: GeneratedActionGroup =
                 CloudActionsForPhysicalProjectsCloudActions_ActionGroup(applicationPlugin)
-            val manager: ActionManagerEx = ActionManagerEx.getInstanceEx()
+            val manager: ActionManager = ActionManager.getInstance()
             var oldAction: AnAction? = manager.getAction(newAction.id)
             if (oldAction == null) {
                 manager.registerAction(newAction.id, newAction, PluginId.getId("org.modelix.model.mpsplugin"))

--- a/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/plugin/CloudNodeGroup_ActionGroup.kt
+++ b/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/plugin/CloudNodeGroup_ActionGroup.kt
@@ -1,7 +1,7 @@
 package org.modelix.model.mpsplugin.plugin
 
+import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import com.intellij.openapi.extensions.PluginId
 import jetbrains.mps.plugins.actions.GeneratedActionGroup
 import jetbrains.mps.workbench.action.ApplicationPlugin
@@ -27,7 +27,7 @@ class CloudNodeGroup_ActionGroup(plugin: ApplicationPlugin) : GeneratedActionGro
         this@CloudNodeGroup_ActionGroup.addAction("org.modelix.model.mpsplugin.plugin.ShowReferences_Action")
         run({
             val newAction: GeneratedActionGroup = CloudNodeGroupAddChild_ActionGroup(applicationPlugin)
-            val manager: ActionManagerEx = ActionManagerEx.getInstanceEx()
+            val manager: ActionManager = ActionManager.getInstance()
             var oldAction: AnAction? = manager.getAction(newAction.id)
             if (oldAction == null) {
                 manager.registerAction(newAction.id, newAction, PluginId.getId("org.modelix.model.mpsplugin"))
@@ -37,7 +37,7 @@ class CloudNodeGroup_ActionGroup(plugin: ApplicationPlugin) : GeneratedActionGro
         })
         run({
             val newAction: GeneratedActionGroup = CloudNodeGroupSetProperty_ActionGroup(applicationPlugin)
-            val manager: ActionManagerEx = ActionManagerEx.getInstanceEx()
+            val manager: ActionManager = ActionManager.getInstance()
             var oldAction: AnAction? = manager.getAction(newAction.id)
             if (oldAction == null) {
                 manager.registerAction(newAction.id, newAction, PluginId.getId("org.modelix.model.mpsplugin"))

--- a/mps-legacy-sync-plugin/src/main/kotlin/org/modelix/mps/sync/ModelixSyncPluginInitializer.kt
+++ b/mps-legacy-sync-plugin/src/main/kotlin/org/modelix/mps/sync/ModelixSyncPluginInitializer.kt
@@ -16,13 +16,14 @@
 
 package org.modelix.mps.sync
 
-import com.intellij.openapi.components.service
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
 
 class ModelixSyncPluginInitializer : StartupActivity.Background {
     override fun runActivity(project: Project) {
-        service<ModelSyncService>().registerProject(project)
+        //service<ModelSyncService>().registerProject(project)
+        ApplicationManager.getApplication().getService(ModelSyncService::class.java).registerProject(project)
     }
 }
 

--- a/mps-legacy-sync-plugin/src/main/resources/META-INF/plugin.xml
+++ b/mps-legacy-sync-plugin/src/main/resources/META-INF/plugin.xml
@@ -26,10 +26,10 @@
     <!-- Extension points defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
     <extensions defaultExtensionNs="com.intellij">
-        <toolWindow id="Modelix History" secondary="false"
+        <toolWindow id="Modelix History" secondary="true"
                     icon="org.modelix.model.mpsplugin.plugin.CloudHistoryTool_Tool.ICON" anchor="bottom"
                     factoryClass="org.modelix.model.mpsplugin.plugin.CloudHistoryTool_Tool"/>
-        <toolWindow id="Modelix Server Connection" secondary="true"
+        <toolWindow id="Modelix Server Connection" secondary="false"
                     icon="org.modelix.model.mpsplugin.plugin.CloudTool_Tool.ICON" anchor="bottom"
                     factoryClass="org.modelix.model.mpsplugin.plugin.CloudTool_Tool"/>
         <applicationService serviceImplementation="org.modelix.mps.sync.ModelSyncService"/>

--- a/mps-legacy-sync-plugin/src/test/kotlin/ProjectCanBeCopiedAndSyncOnCloudTest.kt
+++ b/mps-legacy-sync-plugin/src/test/kotlin/ProjectCanBeCopiedAndSyncOnCloudTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import com.intellij.testFramework.runInEdtAndGet
+import com.intellij.testFramework.EdtTestUtil
 import io.ktor.http.Url
 import jetbrains.mps.project.ModuleId
 import jetbrains.mps.project.Solution
@@ -52,7 +52,7 @@ class ProjectCanBeCopiedAndSyncOnCloudTest : SyncPluginTestBase("SimpleProjectF"
 
         // create new solution in MPS
         val newSolutionId = UUID.fromString("e8a7cec0-ecbb-4e2f-b9cd-74f510383c39")
-        val newSolution = runInEdtAndGet {
+        val newSolution = EdtTestUtil.runInEdtAndGet<_, Throwable> {
             writeAction {
                 MPSProjectUtils.createModule(
                     mpsProject,

--- a/mps-legacy-sync-plugin/src/test/kotlin/SyncPluginTestBase.kt
+++ b/mps-legacy-sync-plugin/src/test/kotlin/SyncPluginTestBase.kt
@@ -17,8 +17,8 @@
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.Disposer
 import com.intellij.serviceContainer.AlreadyDisposedException
+import com.intellij.testFramework.EdtTestUtil
 import com.intellij.testFramework.HeavyPlatformTestCase
-import com.intellij.testFramework.runInEdtAndWait
 import io.ktor.client.HttpClient
 import io.ktor.http.Url
 import io.ktor.serialization.kotlinx.json.json
@@ -41,7 +41,6 @@ import org.jetbrains.mps.openapi.model.SModel
 import org.jetbrains.mps.openapi.model.SNode
 import org.jetbrains.mps.openapi.module.SModule
 import org.modelix.authorization.installAuthentication
-import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.client2.IModelClientV2
 import org.modelix.model.client2.ModelClientV2
@@ -51,7 +50,6 @@ import org.modelix.model.lazy.BranchReference
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.mpsadapters.mps.ProjectAsNode
 import org.modelix.model.mpsadapters.mps.SModuleAsNode
-import org.modelix.model.mpsplugin.SModuleUtils
 import org.modelix.model.server.handlers.KeyValueLikeModelServer
 import org.modelix.model.server.handlers.ModelReplicationServer
 import org.modelix.model.server.handlers.RepositoriesManager
@@ -65,7 +63,6 @@ import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 
 @Suppress("removal")
-@OptIn(UnstableModelixFeature::class)
 abstract class SyncPluginTestBase(private val testDataName: String?) : HeavyPlatformTestCase() {
     protected val baseUrl = "http://localhost/v2/"
     protected lateinit var httpClient: HttpClient
@@ -144,7 +141,7 @@ abstract class SyncPluginTestBase(private val testDataName: String?) : HeavyPlat
     }
 
     override fun setUpProject() {
-        runInEdtAndWait {
+        EdtTestUtil.runInEdtAndGet<_, Throwable> {
             super.setUpProject()
             @Suppress("removal")
             MPSCoreComponents.getInstance().getLibraryInitializer().load(
@@ -161,7 +158,7 @@ abstract class SyncPluginTestBase(private val testDataName: String?) : HeavyPlat
     }
 
     override fun tearDown() {
-        runInEdtAndWait {
+        EdtTestUtil.runInEdtAndGet<_, Throwable> {
             try {
                 super.tearDown()
             } catch (ex: AlreadyDisposedException) {
@@ -171,7 +168,7 @@ abstract class SyncPluginTestBase(private val testDataName: String?) : HeavyPlat
     }
 
     override fun setUp() {
-        runInEdtAndWait {
+        EdtTestUtil.runInEdtAndGet<_, Throwable> {
             super.setUp()
         }
     }


### PR DESCRIPTION
The mps-legacy-sync-plugin didn't work in all MPS versions, because of binary incompatibility of Kotlin APIs, which resulted in LinkageErrors at runtime. The project is now compiled twice, for the oldest and latest supported MPS version, and the resulting jar files are checked for diferences.

Required for MODELIX-672