### PR TITLE
 fix(mps-legacy-sync-plugin): fix initial synchronization of references in models

### DIFF
--- a/mps-legacy-sync-plugin/src/main/kotlin/org/modelix/mps/sync/ModelSyncService.kt
+++ b/mps-legacy-sync-plugin/src/main/kotlin/org/modelix/mps/sync/ModelSyncService.kt
@@ -113,7 +113,7 @@ class ModelSyncService : Disposable, ISyncService {
     private fun getRootBindings() = ModelServerConnections.instance.modelServers
         .flatMap(ModelServerConnection::getRootBindings)
 
-    private fun flushAllBindings() {
+    override fun flushAllBindings() {
         getRootBindings().forEach { it.syncQueue.flush() }
     }
 

--- a/mps-legacy-sync-plugin/src/main/kotlin/org/modelix/mps/sync/api/ISyncService.kt
+++ b/mps-legacy-sync-plugin/src/main/kotlin/org/modelix/mps/sync/api/ISyncService.kt
@@ -40,6 +40,11 @@ interface ISyncService {
      *
      * Returns zero Modelix nodes, when no binding exists or the bind did not sync the MPS Nodes.
      * Returns more than one Modelix node when multiple bindings are syncing the MPS Node.
+     *
+     * This high-level API attempts to synchronize and wait for outstanding synchronizations
+     * between MPS and the model server before looking up nodes in bindings.
+     * The synchronization is always scheduled on a different thread which will try to acquire a write and read lock.
+     * To not deadlock your program, do not call this method while holding a write lock or read lock.
      */
     fun findCloudNodeReference(mpsNode: SNode): List<INode>
 
@@ -50,6 +55,11 @@ interface ISyncService {
      *
      * Returns zero MPS nodes, when no binding exists or the bind did not sync the Modelix Nodes.
      * Returns more than one MPS node when multiple bindings are syncing the Modelix Node.
+     *
+     * This high-level API attempts to synchronize and wait for outstanding synchronizations
+     * between MPS and the model server before looking up nodes in bindings.
+     * The synchronization is always scheduled on a different thread which will try to acquire a write and read lock.
+     * To not deadlock your program, do not call this method while holding a write lock or read lock.
      */
     fun findMpsNode(cloudNodeReference: INodeReference): List<SNode>
 }

--- a/mps-legacy-sync-plugin/src/main/kotlin/org/modelix/mps/sync/api/ISyncService.kt
+++ b/mps-legacy-sync-plugin/src/main/kotlin/org/modelix/mps/sync/api/ISyncService.kt
@@ -62,6 +62,15 @@ interface ISyncService {
      * To not deadlock your program, do not call this method while holding a write lock or read lock.
      */
     fun findMpsNode(cloudNodeReference: INodeReference): List<SNode>
+
+    /**
+     * Synchronize all bindings between MPS and the model server.
+     * The call blocks until all synchronizations are finished or timeout.
+     *
+     * The synchronization is always scheduled on a different thread which will try to acquire a write and read lock.
+     * To not deadlock your program, do not call this method while holding a write lock or read lock.
+     */
+    fun flushAllBindings()
 }
 
 interface IModelServerConnection : Disposable {

--- a/mps-legacy-sync-plugin/src/test/kotlin/FindingNodesInBindingTest.kt
+++ b/mps-legacy-sync-plugin/src/test/kotlin/FindingNodesInBindingTest.kt
@@ -15,7 +15,6 @@
  */
 
 import io.ktor.http.Url
-import kotlinx.coroutines.delay
 import org.jetbrains.mps.openapi.language.SConcept
 import org.jetbrains.mps.openapi.model.SNode
 import org.modelix.model.api.PNodeReference
@@ -80,9 +79,9 @@ class FindingNodesInBindingTest : SyncPluginTestBase("projectWithOneEmptyModel")
     }
 
     fun `test can find cloud nodes and MPS nodes when connection by legacy API`() = runTestWithSyncService { syncService ->
-        // Using ModelCloudImportUtils.copyAndSyncInModelixAsIndependentModule
-        // instead of IBranchConnection.bindModule is the legacy API
-        // The old API must be supported as it is used in actions like CopyAndSyncPhysicalModuleOnCloud_Action
+        // Using the legacy API ModelCloudImportUtils.copyAndSyncInModelixAsIndependentModule
+        // instead of IBranchConnection.bindModule.
+        // The legacy API must be supported as it is used in actions like CopyAndSyncPhysicalModuleOnCloud_Action
 
         // Arrange: Create data
         val classConcept = resolveMPSConcept("jetbrains.mps.baseLanguage.ClassConcept")
@@ -130,16 +129,5 @@ class FindingNodesInBindingTest : SyncPluginTestBase("projectWithOneEmptyModel")
         assertEquals(2, cloudNodes.size)
         assertEquals(newRootNode, mpsNodeFromFirstSecondCloudNode)
         assertEquals(mpsNodeFromFirstCloudNode, mpsNodeFromFirstSecondCloudNode)
-    }
-
-    private suspend fun delayUntil(condition: () -> Boolean) {
-        var remainingDelays = 30
-        while (!condition()) {
-            delay(1000)
-            remainingDelays--
-            if (remainingDelays == 0) {
-                throw IllegalStateException("Waited too long.")
-            }
-        }
     }
 }

--- a/mps-legacy-sync-plugin/src/test/kotlin/ReferenceSynchronisationTest.kt
+++ b/mps-legacy-sync-plugin/src/test/kotlin/ReferenceSynchronisationTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.ktor.http.Url
+import org.modelix.model.api.PNodeReference
+import org.modelix.model.data.NodeData
+import org.modelix.model.lazy.filterNotNullValues
+import org.modelix.model.mpsplugin.ModelCloudImportUtils
+import org.modelix.model.mpsplugin.ModelServerConnections
+
+class ReferenceSynchronisationTest : SyncPluginTestBase("projectWithReferences") {
+
+    private fun assertAllReferencesArePNodeReferences(nodeData: NodeData) {
+        for ((referenceRole, referenceValue) in nodeData.references) {
+            val reference = PNodeReference.tryDeserialize(referenceValue)
+            assertNotNull(
+                "Reference is not a PNodeReference. [node=${nodeData.id}] [role=$referenceRole] [reference=$referenceValue]",
+                reference,
+            )
+        }
+        nodeData.children.forEach(::assertAllReferencesArePNodeReferences)
+    }
+
+    private fun countSetReferences(nodeData: NodeData): Int =
+        nodeData.references.filterNotNullValues().size + nodeData.children.map(::countSetReferences).sum()
+
+    private fun assertNumberOfSetReferences(expectedNumberOfSetReferences: Int, nodeData: NodeData) {
+        val actualNumberSetOfReferences = countSetReferences(nodeData)
+        assertEquals(expectedNumberOfSetReferences, actualNumberSetOfReferences)
+    }
+
+    fun `test references are initially synced as  modelix references in module`() =
+        runTestWithSyncService { syncService ->
+            // Arrange
+            val existingSolution = mpsProject.projectModules.single()
+
+            // Act
+            val moduleBinding = syncService.connectServer(httpClient, Url("http://localhost/"))
+                .newBranchConnection(defaultBranchRef)
+                .bindModule(existingSolution, null)
+            moduleBinding.flush()
+
+            // Assert
+            val rootNodeData = readDumpFromServer(defaultBranchRef)
+            // The model has exactly two references.
+            assertNumberOfSetReferences(2, rootNodeData)
+            assertAllReferencesArePNodeReferences(rootNodeData)
+        }
+
+    fun `test references are initially synced as modelix references in module when connecting by legacy API`() =
+        runTestWithSyncService { syncService ->
+            // Using the legacy API ModelCloudImportUtils.copyAndSyncInModelixAsIndependentModule
+            // instead of IBranchConnection.bindModule.
+            // The legacy API must be supported as it is used in actions like CopyAndSyncPhysicalModuleOnCloud_Action
+
+            // Arrange
+            val existingSolution = mpsProject.projectModules.single()
+            syncService.connectServer(httpClient, Url("http://localhost/"))
+            val modelServer = ModelServerConnections.instance.modelServers.single()
+            // Arrange: Setup bindings
+            // after `info` is fetched, we can start adding repositories
+            delayUntil { modelServer.info != null }
+            delayUntil {
+                ModelServerConnections.instance.connectedTreesInRepositories
+                    .map { it.branch.getId() }
+                    .containsAll(listOf(defaultBranchRef.repositoryId.id))
+            }
+            val repositoryTree = ModelServerConnections.instance.connectedTreesInRepositories
+                .single { it.branch.getId() == defaultBranchRef.repositoryId.id }
+
+            // Act
+            writeAction {
+                ModelCloudImportUtils.copyAndSyncInModelixAsIndependentModule(
+                    repositoryTree,
+                    existingSolution,
+                    project,
+                    null,
+                )
+            }
+            syncService.flushAllBindings()
+
+            // Assert
+            val rootNodeData = readDumpFromServer(defaultBranchRef)
+            // The model has exactly two references.
+            assertNumberOfSetReferences(2, rootNodeData)
+            assertAllReferencesArePNodeReferences(rootNodeData)
+        }
+}

--- a/mps-legacy-sync-plugin/src/test/kotlin/SyncPluginTestBase.kt
+++ b/mps-legacy-sync-plugin/src/test/kotlin/SyncPluginTestBase.kt
@@ -33,6 +33,7 @@ import jetbrains.mps.library.contributor.LibDescriptor
 import jetbrains.mps.project.MPSProject
 import jetbrains.mps.smodel.adapter.structure.concept.InvalidConcept
 import jetbrains.mps.smodel.language.LanguageRegistry
+import kotlinx.coroutines.delay
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.jetbrains.mps.openapi.language.SAbstractConcept
@@ -64,6 +65,30 @@ import kotlin.io.path.absolutePathString
 
 @Suppress("removal")
 abstract class SyncPluginTestBase(private val testDataName: String?) : HeavyPlatformTestCase() {
+
+    companion object {
+        suspend fun delayUntil(
+            checkIntervalMilliseconds: Long = 1000,
+            timeoutMilliseconds: Long = 30_000,
+            condition: () -> Boolean,
+        ) {
+            check(checkIntervalMilliseconds > 0) {
+                "checkIntervalMilliseconds must be positive."
+            }
+            check(timeoutMilliseconds > 0) {
+                "timeoutMilliseconds must be positive."
+            }
+            var remainingDelays = timeoutMilliseconds / checkIntervalMilliseconds
+            while (!condition()) {
+                if (remainingDelays == 0L) {
+                    throw IllegalStateException("Waited too long.")
+                }
+                delay(checkIntervalMilliseconds)
+                remainingDelays--
+            }
+        }
+    }
+
     protected val baseUrl = "http://localhost/v2/"
     protected lateinit var httpClient: HttpClient
     protected lateinit var syncService: ISyncService

--- a/mps-legacy-sync-plugin/testdata/projectWithReferences/.mps/.gitignore
+++ b/mps-legacy-sync-plugin/testdata/projectWithReferences/.mps/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/mps-legacy-sync-plugin/testdata/projectWithReferences/.mps/migration.xml
+++ b/mps-legacy-sync-plugin/testdata/projectWithReferences/.mps/migration.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MigrationProperties">
+    <entry key="project.baseline.version" value="211" />
+  </component>
+</project>

--- a/mps-legacy-sync-plugin/testdata/projectWithReferences/.mps/modules.xml
+++ b/mps-legacy-sync-plugin/testdata/projectWithReferences/.mps/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MPSProject">
+    <projectModules>
+      <modulePath path="$PROJECT_DIR$/solutions/NewSolution/NewSolution.msd" folder="" />
+    </projectModules>
+  </component>
+</project>

--- a/mps-legacy-sync-plugin/testdata/projectWithReferences/.mps/vcs.xml
+++ b/mps-legacy-sync-plugin/testdata/projectWithReferences/.mps/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+  </component>
+</project>

--- a/mps-legacy-sync-plugin/testdata/projectWithReferences/solutions/NewSolution/NewSolution.msd
+++ b/mps-legacy-sync-plugin/testdata/projectWithReferences/solutions/NewSolution/NewSolution.msd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="NewSolution" uuid="f82c5b00-8ddf-478e-ab7c-27ce8087ec45" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="f82c5b00-8ddf-478e-ab7c-27ce8087ec45(NewSolution)" version="0" />
+  </dependencyVersions>
+</solution>

--- a/mps-legacy-sync-plugin/testdata/projectWithReferences/solutions/NewSolution/models/NewSolution.a_model.mps
+++ b/mps-legacy-sync-plugin/testdata/projectWithReferences/solutions/NewSolution/models/NewSolution.a_model.mps
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:7834ce38-0c6e-4f10-8390-d6c40765da4f(NewSolution.a_model)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+  </languages>
+  <imports />
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="1b97tCqtR4X">
+    <property role="TrG5h" value="ClassA" />
+    <node concept="Wx3nA" id="1b97tCqtU9w" role="jymVt">
+      <property role="TrG5h" value="classBreference" />
+      <node concept="3uibUv" id="1b97tCqtU9x" role="1tU5fm">
+        <ref role="3uigEE" node="1b97tCqtU7Y" resolve="ClassB" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="1b97tCqtR4Y" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="1b97tCqtU7Y">
+    <property role="TrG5h" value="ClassB" />
+    <node concept="Wx3nA" id="1b97tCqtU91" role="jymVt">
+      <property role="TrG5h" value="classAreference" />
+      <node concept="3uibUv" id="1b97tCqtU8Q" role="1tU5fm">
+        <ref role="3uigEE" node="1b97tCqtR4X" resolve="ClassA" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="1b97tCqtU7Z" role="1B3o_S" />
+  </node>
+</model>


### PR DESCRIPTION
Previously, a reference was not synced as PNodeReference if the referenced node not was already seen.

The fix is done for the initial sync in the legacy API.
The new API is not used because it does not support callbacks for progress monitor.
Extending the new API is not reasonable because the plugin is currently rewritten.

The same still exists for references between nodes in different models and in different modules. But it is harder to fix.

