### PR TITLE
fix(mps-legacy-sync-plugin): fix `ModelSyncService` initialization

### DIFF
--- a/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/ModelServerConnection.kt
+++ b/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/ModelServerConnection.kt
@@ -96,8 +96,11 @@ class ModelServerConnection @JvmOverloads constructor(baseUrl: String, providedH
         val workspaceTokenProvider: () -> String? = { InstanceJwtToken.token }
         val tokenProvider: (() -> String?)? =
             (if (ModelixConfigurationSystemProperties.executionMode == EModelixExecutionMode.PROJECTOR) workspaceTokenProvider else null)
-        val syncService = ApplicationManager.getApplication().getService(ModelSyncService::class.java)
-        val httpClient = providedHttpClient ?: syncService.httpClient
+        // Do not use ApplicationManager.getApplication().getService(ModelSyncService::class.java) here
+        // because this code might get called from ModelSyncService.<init>.
+        // This will cause MPS to try to create the ModelSyncService a second time and fail.
+        val syncService = ModelSyncService.INSTANCE
+        val httpClient = providedHttpClient ?: syncService?.httpClient
         client = RestWebModelClient(
             baseUrl,
             tokenProvider,


### PR DESCRIPTION
`ModelSyncService.<init>` was called from within `ModelSyncService.<init>` when a cloud repository was set (see. CLOUD_REPOS_SYSPROP).