### PR TITLE
Do not completely synchronize read-only modules and models

### DIFF
--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/ModelixSyncPluginConcepts.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/ModelixSyncPluginConcepts.kt
@@ -1,0 +1,83 @@
+package org.modelix.mps.sync.modelix
+
+import org.modelix.model.api.BuiltinLanguages
+import org.modelix.model.api.BuiltinLanguages.MPSRepositoryConcepts.Module
+import org.modelix.model.api.BuiltinLanguages.jetbrains_mps_lang_core
+import org.modelix.model.api.SimpleChildLink
+import org.modelix.model.api.SimpleConcept
+import org.modelix.model.api.SimpleLanguage
+import org.modelix.model.api.SimpleReferenceLink
+
+object ModelixSyncPluginConcepts :
+    SimpleLanguage("org.modelix.model.syncpluginconcepts", uid = "mps:0a7577d1-d4e5-431d-98b1-fae38f9aee81") {
+
+    override var includedConcepts =
+        arrayOf(ReadonlyModel, ReadonlyModule, ReadonlyModuleDependency, ReadonlyModelReference, ReadonlyModelNode)
+
+    object ReadonlyModel : SimpleConcept(
+        conceptName = "ReadonlyModel",
+        uid = "mps:0a7577d1-d4e5-431d-98b1-fae38f9aee81/474657388638618893",
+        directSuperConcepts = listOf(BuiltinLanguages.MPSRepositoryConcepts.Model),
+    ) {
+        init {
+            addConcept(this)
+        }
+    }
+
+    object ReadonlyModule : SimpleConcept(
+        conceptName = "ReadonlyModule",
+        uid = "mps:0a7577d1-d4e5-431d-98b1-fae38f9aee81/474657388638618896",
+        directSuperConcepts = listOf(Module),
+    ) {
+        init {
+            addConcept(this)
+        }
+
+        val readonlyModels = SimpleChildLink(
+            simpleName = "readonlyModels",
+            isMultiple = true,
+            isOptional = true,
+            isOrdered = false,
+            targetConcept = ReadonlyModel,
+            uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee81/474657388638618896/474657388638618899",
+        ).also(this::addChildLink)
+    }
+
+    object ReadonlyModuleDependency : SimpleConcept(
+        conceptName = "ReadonlyModuleDependency",
+        uid = "mps:0a7577d1-d4e5-431d-98b1-fae38f9aee81/2206727074858242416",
+        directSuperConcepts = listOf(BuiltinLanguages.MPSRepositoryConcepts.ModuleDependency),
+    ) {
+
+        init {
+            addConcept(this)
+        }
+    }
+
+    object ReadonlyModelReference : SimpleConcept(
+        conceptName = "ReadonlyModelReference",
+        uid = "mps:0a7577d1-d4e5-431d-98b1-fae38f9aee81/6402965165736932004",
+        directSuperConcepts = listOf(BuiltinLanguages.MPSRepositoryConcepts.ModelReference),
+    ) {
+        init {
+            addConcept(this)
+        }
+
+        val readonlyModel = SimpleReferenceLink(
+            simpleName = "readonlyModel",
+            isOptional = false,
+            targetConcept = ReadonlyModel,
+            uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee81/6402965165736932004/6402965165736932005",
+        )
+    }
+
+    object ReadonlyModelNode : SimpleConcept(
+        conceptName = "ReadonlyModelNode",
+        uid = "mps:0a7577d1-d4e5-431d-98b1-fae38f9aee81/6402965165736932005",
+        directSuperConcepts = listOf(jetbrains_mps_lang_core.BaseConcept),
+    ) {
+        init {
+            addConcept(this)
+        }
+    }
+}

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/util/INodeExt.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/util/INodeExt.kt
@@ -25,6 +25,7 @@ import org.modelix.model.api.INode
 import org.modelix.model.api.PNodeAdapter
 import org.modelix.model.api.isSubConceptOf
 import org.modelix.model.mpsadapters.MPSNode
+import org.modelix.mps.sync.modelix.ModelixSyncPluginConcepts
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "This feature is finalized when the new sync plugin is ready for release.")
 fun INode.nodeIdAsLong(): Long =
@@ -81,6 +82,43 @@ fun INode.isModuleDependency(): Boolean {
     val concept = this.concept ?: return false
     val moduleDepConceptRef = BuiltinLanguages.MPSRepositoryConcepts.ModuleDependency.getReference()
     return concept.isSubConceptOf(moduleDepConceptRef)
+}
+
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "This feature is finalized when the new sync plugin is ready for release.")
+fun INode.isReadonlyModule(): Boolean {
+    val concept = this.concept ?: return false
+    val moduleConceptRef = ModelixSyncPluginConcepts.ReadonlyModule.getReference()
+    return concept.isSubConceptOf(moduleConceptRef)
+}
+
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "This feature is finalized when the new sync plugin is ready for release.")
+fun INode.isReadonlyModel(): Boolean {
+    val concept = this.concept ?: return false
+    val modelConceptRef = ModelixSyncPluginConcepts.ReadonlyModel.getReference()
+    return concept.isSubConceptOf(modelConceptRef)
+}
+
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "This feature is finalized when the new sync plugin is ready for release.")
+fun INode.isReadonlyModelNode(): Boolean {
+    val concept = this.concept ?: return false
+    val modelConceptRef = ModelixSyncPluginConcepts.ReadonlyModelNode.getReference()
+    return concept.isSubConceptOf(modelConceptRef)
+}
+
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "This feature is finalized when the new sync plugin is ready for release.")
+fun INode.isReadonlyModuleDependency(): Boolean {
+    val concept = this.concept ?: return false
+    val moduleDepConceptRef = ModelixSyncPluginConcepts.ReadonlyModuleDependency.getReference()
+    return concept.isSubConceptOf(moduleDepConceptRef)
+}
+
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "This feature is finalized when the new sync plugin is ready for release.")
+fun INode.isReadonlyModelImport(): Boolean {
+    val concept = this.concept ?: return false
+    val modelReferenceConceptRef = ModelixSyncPluginConcepts.ReadonlyModelReference.getReference()
+    val isModelReference = concept.isSubConceptOf(modelReferenceConceptRef)
+    val isModelImportRole = BuiltinLanguages.MPSRepositoryConcepts.Model.modelImports == this.getContainmentLink()
+    return isModelReference && isModelImportRole
 }
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "This feature is finalized when the new sync plugin is ready for release.")

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/services/MPSLanguageRepositoryProvider.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/services/MPSLanguageRepositoryProvider.kt
@@ -6,6 +6,7 @@ import jetbrains.mps.smodel.MPSModuleRepository
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.api.ILanguageRepository
 import org.modelix.model.mpsadapters.MPSLanguageRepository
+import org.modelix.mps.sync.modelix.ModelixSyncPluginConcepts
 
 @UnstableModelixFeature(
     reason = "The new modelix MPS plugin is under construction",
@@ -17,8 +18,8 @@ class MPSLanguageRepositoryProvider {
     val mpsLanguageRepository: MPSLanguageRepository
 
     init {
-        // just a dummy call, to initialize the modelix built-in languages
-        ILanguageRepository.default.javaClass
+        // initialize the modelix built-in languages
+        ILanguageRepository.default.registerLanguage(ModelixSyncPluginConcepts)
 
         // MPS-internal convention that they use to get the SRepository
         val repository = MPSCoreComponents.getInstance().platform.findComponent(MPSModuleRepository::class.java)

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/services/ServiceLocator.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/services/ServiceLocator.kt
@@ -30,6 +30,7 @@ import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 class ServiceLocator(val project: Project) : Disposable {
 
     val syncService = SyncServiceImpl()
+
     val syncQueue = SyncQueue()
     val bindingsRegistry = BindingsRegistry()
     val branchRegistry = BranchRegistry()

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/initial/ITreeToSTreeTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/initial/ITreeToSTreeTransformer.kt
@@ -46,10 +46,9 @@ class ITreeToSTreeTransformer(
     fun transform(moduleId: String): Iterable<IBinding> {
         val result = syncQueue.enqueue(linkedSetOf(SyncLock.MODELIX_READ), SyncDirection.NONE) {
             val moduleNode = branch.getRootNode().allChildren.firstOrNull {
-                it.getPropertyValue(BuiltinLanguages.MPSRepositoryConcepts.Module.id) == moduleId
+                it.isModule() && it.getPropertyValue(BuiltinLanguages.MPSRepositoryConcepts.Module.id) == moduleId
             }
             requireNotNull(moduleNode) { "Module node with ID '$moduleId' is not found on the root level." }
-            require(moduleNode.isModule()) { "Transformation entry point (Node $moduleNode) must be a Module." }
             val entryNodeId = moduleNode.nodeIdAsLong()
             moduleTransformer.transformToModuleCompletely(entryNodeId, true).getResult()
         }

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/ModelSyncAction.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/ModelSyncAction.kt
@@ -39,6 +39,7 @@ object ModelSyncAction : AnAction("Synchronize Model to Server") {
         actionPerformedSafely(event, logger, "Model synchronization error occurred.") { serviceLocator ->
             val model = event.getData(contextModel) as? SModelBase
             checkNotNull(model) { "Synchronization is not possible, because Model (${model?.name}) is not an SModelBase." }
+            check(!model.isReadOnly) { "Synchronization action is not allowed on read-only Model (${model.name})." }
 
             val branchRegistry = serviceLocator.branchRegistry
             val branch = branchRegistry.getBranch()

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/ModuleSyncAction.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/ModuleSyncAction.kt
@@ -39,6 +39,7 @@ object ModuleSyncAction : AnAction("Synchronize Module to Server") {
         actionPerformedSafely(event, logger, "Module synchronization error occurred.") { serviceLocator ->
             val module = event.getData(contextModule) as? AbstractModule
             checkNotNull(module) { "Synchronization is not possible, because Module (${module?.moduleName}) is not an AbstractModule." }
+            check(!module.isReadOnly) { "Synchronization action is not allowed on read-only Module (${module.moduleName})." }
 
             val branchRegistry = serviceLocator.branchRegistry
             val branch = branchRegistry.getBranch()

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/UnbindModelAction.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/UnbindModelAction.kt
@@ -39,6 +39,7 @@ object UnbindModelAction : AnAction("Unbind Model") {
         actionPerformedSafely(event, logger, "Model unbind error occurred.") { serviceLocator ->
             val model = event.getData(contextModel) as? SModelBase
             checkNotNull(model) { "Unbinding is not possible, because Model (${model?.name}) is not an SModelBase." }
+            check(!model.isReadOnly) { "Unbinding is not possible, because Model (${model.name}) is read-only." }
 
             val bindingsRegistry = serviceLocator.bindingsRegistry
             val binding = bindingsRegistry.getModelBinding(model)

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/UnbindModuleAction.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/UnbindModuleAction.kt
@@ -39,6 +39,7 @@ object UnbindModuleAction : AnAction("Unbind Module") {
         actionPerformedSafely(event, logger, "Module unbind error occurred.") { serviceLocator ->
             val module = event.getData(contextModule) as? AbstractModule
             checkNotNull(module) { "Unbinding is not possible, because Module (${module?.moduleName}) is not an AbstractModule." }
+            check(!module.isReadOnly) { "Unbinding is not possible, because Module (${module.moduleName}) is read-only." }
 
             val bindingsRegistry = serviceLocator.bindingsRegistry
             val binding = bindingsRegistry.getModuleBinding(module)

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/gui/ModelSyncGuiFactory.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/gui/ModelSyncGuiFactory.kt
@@ -165,12 +165,12 @@ class ModelSyncGuiFactory : ToolWindowFactory {
             val inputBox = Box.createVerticalBox()
 
             val urlPanel = JPanel()
-            urlPanel.add(JLabel("Server URL:    "))
+            urlPanel.add(JLabel("Server URL:"))
             urlPanel.add(serverURL)
             inputBox.add(urlPanel)
 
             val jwtPanel = JPanel()
-            jwtPanel.add(JLabel("JWT:           "))
+            jwtPanel.add(JLabel("JWT:"))
             jwtPanel.add(jwt)
 
             connectButton.addActionListener {


### PR DESCRIPTION
The idea is to synchronize only those parts of the read-only Modules and Models that are used in MPS:

- Modules and all their Models, because it makes creating Model Imports for read-only Models easier,
- Models,
- Module Dependencies for read-only Modules but not between the read-only Modules,
- Model Imports for read-only Models but not between the read-only Models,
- Nodes that are referred to in our MPS models. All such Nodes are added as rootNode to the read-only Models. Although it may make the uploaded read-only Models structurally invalid, but we do not read those Models via their original, generated language so it's fine. 

I've developed a new language for the read-only Modules, Models, etc that should be safe to use as meta-model to read the aforementioned modelix nodes.

Such feature comes in handy, when we have a DevKit in a plugin that imports a lot of languages and Modules that we do not want to sync to the cloud, but we also do not want to lose the references for them (and the nodes used from them).

**Bug (!!!):** test the code if it works when we have a DevKit and a module that is synchronized to modelix and we add a new model import / node referenece / module dependency, etc. to a model/module/node that is readonly, but is not synchronized to modelix yet. Do we synchronize the references and the targets in this case?