### PR TITLE
Use authProvider instead of static jwt string in the SyncServiceImpl

### DIFF
--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/IRebindModulesSyncService.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/IRebindModulesSyncService.kt
@@ -21,12 +21,12 @@ interface IRebindModulesSyncService {
      * Creates a connection to the model server. Do not forget to close the created client after use.
      *
      * @param serverURL the model server URL
-     * @param jwt the JWT auth token
+     * @param authProvider a function that generates a JWT token that can be used for auth
      *
      * @return the model client that is connected to the model server
      */
     @Throws(IOException::class)
-    fun connectModelServer(serverURL: String, jwt: String? = null): ModelClientV2?
+    fun connectModelServer(serverURL: String, authProvider: () -> String? = { null }): ModelClientV2?
 
     /**
      * Connects to the model server's specific branch's specific version, and creates [IBinding]s for the modules and

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/ISyncService.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/ISyncService.kt
@@ -14,10 +14,10 @@ import java.util.concurrent.CompletableFuture
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "This feature is finalized when the new sync plugin is ready for release.")
 interface ISyncService : IRebindModulesSyncService {
 
-    override fun connectModelServer(serverURL: String, jwt: String?) = connectModelServer(URL(serverURL), jwt)
+    override fun connectModelServer(serverURL: String, authProvider: () -> String?) = connectModelServer(URL(serverURL), authProvider)
 
     @Throws(IOException::class)
-    fun connectModelServer(serverURL: URL, jwt: String? = null): ModelClientV2
+    fun connectModelServer(serverURL: URL, authProvider: () -> String?): ModelClientV2
 
     fun disconnectModelServer(client: ModelClientV2)
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/SyncServiceImpl.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/SyncServiceImpl.kt
@@ -67,9 +67,9 @@ class SyncServiceImpl : ISyncService, InjectableService {
     }
 
     @Throws(IOException::class)
-    override fun connectModelServer(serverURL: URL, jwt: String?): ModelClientV2 {
+    override fun connectModelServer(serverURL: URL, authProvider: () -> String?): ModelClientV2 {
         logger.info { "Connecting to $serverURL" }
-        val modelClientV2 = ModelClientV2.builder().url(serverURL.toString()).authToken { jwt }.build()
+        val modelClientV2 = ModelClientV2.builder().url(serverURL.toString()).authToken(authProvider).build()
         runBlocking(networkDispatcher) {
             modelClientV2.init()
         }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/persistence/PersistableState.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/persistence/PersistableState.kt
@@ -105,7 +105,7 @@ data class PersistableState(
      *
      * @return some context statistics about the restored state
      */
-    fun restoreState(syncService: IRebindModulesSyncService, project: Project): RestoredStateContext? {
+    fun restoreState(syncService: IRebindModulesSyncService, project: Project, authProvider: () -> String? = { null }): RestoredStateContext? {
         var client: ModelClientV2? = null
 
         try {
@@ -121,7 +121,7 @@ data class PersistableState(
 
             logger.debug { "Restoring connection to model server." }
             // TODO FIXME auth token is missing
-            client = syncService.connectModelServer(clientUrl)
+            client = syncService.connectModelServer(clientUrl, authProvider)
             if (client == null) {
                 throw IllegalStateException("Connection to $clientUrl failed, thus PersistableState is not restored.")
             }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/persistence/PersistableState.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/persistence/PersistableState.kt
@@ -120,7 +120,8 @@ data class PersistableState(
             }
 
             logger.debug { "Restoring connection to model server." }
-            client = syncService.connectModelServer(clientUrl, "")
+            // TODO FIXME auth token is missing
+            client = syncService.connectModelServer(clientUrl)
             if (client == null) {
                 throw IllegalStateException("Connection to $clientUrl failed, thus PersistableState is not restored.")
             }

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/ModelSyncService.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/ModelSyncService.kt
@@ -82,10 +82,10 @@ class ModelSyncService(project: Project) : IRebindModulesSyncService {
         logger.debug { "ModelixSyncPlugin: InjectableNotifierWrapper is initialized" }
     }
 
-    override fun connectModelServer(serverURL: String, jwt: String?): ModelClientV2? {
+    override fun connectModelServer(serverURL: String, authProvider: () -> String?): ModelClientV2? {
         var client: ModelClientV2? = null
         try {
-            client = syncService.connectModelServer(URL(serverURL), jwt)
+            client = syncService.connectModelServer(URL(serverURL), authProvider)
             notifier.notifyAndLogInfo("Connected to server: $serverURL", logger)
         } catch (t: Throwable) {
             val message = "Unable to connect to $serverURL. Cause: ${t.message}"

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/gui/ModelSyncGuiFactory.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/gui/ModelSyncGuiFactory.kt
@@ -181,7 +181,7 @@ class ModelSyncGuiFactory : ToolWindowFactory {
                     return@addActionListener
                 }
 
-                val client = modelSyncService.connectModelServer(serverURL.text, jwt.text)
+                val client = modelSyncService.connectModelServer(serverURL.text) { jwt.text }
                 triggerRefresh(client)
             }
             jwtPanel.add(connectButton)


### PR DESCRIPTION
**Bug:** if we test this branch with the courses example from modelix.samples on a model server where JWT auth is enabled, and we set the JWT token in the plugin's UI, (and start the upload process), then the whole model server will be paralized and the upload process is aborted due to timeout in the background.

However, from the sync plugin's perspective everything seems to be fine, because the Bindings got activated.

It's because the ModelClientV2 syncs the data on a different Coroutine than where the MPS to modelix transformation tasks are running, and that Coroutine finishes/aborts in the background with these exceptions:

```
2024-10-15 07:54:41,905 [ 142082]   INFO -                         STDOUT - 07:54:41.903 [DefaultDispatcher-worker-18] INFO  o.modelix.mps.sync.SyncServiceImpl - Connecting to branch branch_testrepo_main with initial version null (null = latest version). 
2024-10-15 07:54:42,761 [ 142938]   INFO -                         STDOUT - 07:54:42.760 [DefaultDispatcher-worker-18] INFO  o.modelix.mps.sync.SyncServiceImpl - Connected to branch branch_testrepo_main with initial version null 
2024-10-15 07:54:42,761 [ 142938]   INFO -                         STDOUT - 07:54:42.761 [DefaultDispatcher-worker-3] INFO  o.m.mps.sync.plugin.ModelSyncService - Connected to branch: branch_testrepo_main 
2024-10-15 07:54:46,713 [ 146890]   INFO -                         STDOUT - 07:54:46.712 [AWT-EventQueue-0] INFO  o.modelix.mps.sync.SyncServiceImpl - Binding Module 'University.Schedule.modelserver.backend.sandbox' to the server. 
2024-10-15 07:54:47,099 [ 147276]   INFO -                         STDOUT - 07:54:47.099 [AWT-EventQueue-0] INFO  o.modelix.mps.sync.SyncServiceImpl - Module- and Model Bindings for Module 'University.Schedule.modelserver.backend.sandbox' are created. 
2024-10-15 07:54:47,160 [ 147337]   INFO -                         STDOUT - 07:54:47.159 [AWT-EventQueue-0] INFO  o.m.mps.sync.bindings.ModelBinding - Binding of Model 'University.Schedule.modelserver.backend.sandbox' is activated. 
2024-10-15 07:54:47,206 [ 147383]   INFO -                         STDOUT - 07:54:47.206 [AWT-EventQueue-0] INFO  o.m.mps.sync.bindings.ModuleBinding - Binding of Module 'University.Schedule.modelserver.backend.sandbox' is activated. 
2024-10-15 07:54:47,255 [ 147432]   INFO -                         STDOUT - 07:54:47.254 [AWT-EventQueue-0] INFO  o.m.mps.sync.bindings.ModelBinding - Binding of Model 'A.M2' is activated. 
2024-10-15 07:54:47,297 [ 147474]   INFO -                         STDOUT - 07:54:47.296 [AWT-EventQueue-0] INFO  o.m.mps.sync.bindings.ModelBinding - Binding of Model 'A.M3' is activated. 
2024-10-15 07:54:47,337 [ 147514]   INFO -                         STDOUT - 07:54:47.337 [AWT-EventQueue-0] INFO  o.m.mps.sync.bindings.ModelBinding - Binding of Model 'A.M1' is activated. 
2024-10-15 07:54:47,375 [ 147552]   INFO -                         STDOUT - 07:54:47.375 [AWT-EventQueue-0] INFO  o.m.mps.sync.bindings.ModuleBinding - Binding of Module 'A' is activated. 
2024-10-15 07:54:47,409 [ 147586]   INFO -                         STDOUT - 07:54:47.409 [AWT-EventQueue-0] INFO  o.m.mps.sync.bindings.ModelBinding - Binding of Model 'B.N2' is activated. 
2024-10-15 07:54:47,446 [ 147623]   INFO -                         STDOUT - 07:54:47.446 [AWT-EventQueue-0] INFO  o.m.mps.sync.bindings.ModelBinding - Binding of Model 'B.N1' is activated. 
2024-10-15 07:54:47,470 [ 147647]   INFO -                         STDOUT - 07:54:47.469 [AWT-EventQueue-0] INFO  o.m.mps.sync.bindings.ModuleBinding - Binding of Module 'B' is activated. 
2024-10-15 07:54:59,156 [ 159333]   INFO - #com.intellij.ide.actions.RevealFileAction - Exit code 1 
2024-10-15 07:54:59,486 [ 159663]   INFO - jetbrains.mps.smodel.MPSModuleRepository - Saving of the repository took 0.001 s 
2024-10-15 07:55:17,117 [ 177294]  ERROR - #com.intellij.ide.plugins.PluginManager - Request timeout has expired [url=http://127.0.0.1:28101/v2/repositories/testrepo/branches/main, request_timeout=30000 ms] 
io.ktor.client.plugins.HttpRequestTimeoutException: Request timeout has expired [url=http://127.0.0.1:28101/v2/repositories/testrepo/branches/main, request_timeout=30000 ms]
	at io.ktor.client.plugins.HttpTimeout$Plugin$install$1$1$killer$1.invokeSuspend(HttpTimeout.kt:165)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@2e98e6cd, Dispatchers.IO]
2024-10-15 07:55:17,117 [ 177294]  ERROR - #com.intellij.ide.plugins.PluginManager - Request timeout has expired [url=http://127.0.0.1:28101/v2/repositories/testrepo/branches/main, request_timeout=30000 ms] 
io.ktor.client.plugins.HttpRequestTimeoutException: Request timeout has expired [url=http://127.0.0.1:28101/v2/repositories/testrepo/branches/main, request_timeout=30000 ms]
	at io.ktor.client.plugins.HttpTimeout$Plugin$install$1$1$killer$1.invokeSuspend(HttpTimeout.kt:165)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@4778574c, Dispatchers.IO]
2024-10-15 07:55:17,117 [ 177294]  ERROR - #com.intellij.ide.plugins.PluginManager - Request timeout has expired [url=http://127.0.0.1:28101/v2/repositories/testrepo/branches/main, request_timeout=30000 ms] 
io.ktor.client.plugins.HttpRequestTimeoutException: Request timeout has expired [url=http://127.0.0.1:28101/v2/repositories/testrepo/branches/main, request_timeout=30000 ms]
	at io.ktor.client.plugins.HttpTimeout$Plugin$install$1$1$killer$1.invokeSuspend(HttpTimeout.kt:165)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@7e421560, Dispatchers.IO]
2024-10-15 07:55:17,117 [ 177294]  ERROR - #com.intellij.ide.plugins.PluginManager - Request timeout has expired [url=http://127.0.0.1:28101/v2/repositories/testrepo/branches/main, request_timeout=30000 ms] 
io.ktor.client.plugins.HttpRequestTimeoutException: Request timeout has expired [url=http://127.0.0.1:28101/v2/repositories/testrepo/branches/main, request_timeout=30000 ms]
	at io.ktor.client.plugins.HttpTimeout$Plugin$install$1$1$killer$1.invokeSuspend(HttpTimeout.kt:165)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@6cff94ec, Dispatchers.IO]
2024-10-15 07:55:17,123 [ 177300]  ERROR - #com.intellij.ide.plugins.PluginManager - JetBrains MPS 2020.3.6  Build #MPS-203.8084.3437 
2024-10-15 07:55:17,117 [ 177294]  ERROR - #com.intellij.ide.plugins.PluginManager - Request timeout has expired [url=http://127.0.0.1:28101/v2/repositories/testrepo/branches/main, request_timeout=30000 ms] 
io.ktor.client.plugins.HttpRequestTimeoutException: Request timeout has expired [url=http://127.0.0.1:28101/v2/repositories/testrepo/branches/main, request_timeout=30000 ms]
	at io.ktor.client.plugins.HttpTimeout$Plugin$install$1$1$killer$1.invokeSuspend(HttpTimeout.kt:165)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@51cfee69, Dispatchers.IO]
```