### PR TITLE
Do not completely synchronize read-only modules and models

### DIFF
--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/SyncServiceImpl.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/SyncServiceImpl.kt
@@ -55,7 +55,7 @@ class SyncServiceImpl : ISyncService, InjectableService {
         get() = serviceLocator.branchRegistry
 
     private val mpsRepository: SRepository
-        get() = serviceLocator.mpsProject.repository
+        get() = serviceLocator.mpsRepository
 
     private val languageRepository: MPSLanguageRepository
         get() = serviceLocator.languageRepository

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/branch/BranchRegistry.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/branch/BranchRegistry.kt
@@ -16,9 +16,9 @@
 
 package org.modelix.mps.sync.modelix.branch
 
-import jetbrains.mps.project.MPSProject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
+import org.jetbrains.mps.openapi.module.SRepository
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.api.IBranch
 import org.modelix.model.client2.ModelClientV2
@@ -38,8 +38,8 @@ class BranchRegistry : InjectableService {
 
     private lateinit var serviceLocator: ServiceLocator
 
-    private val mpsProject: MPSProject
-        get() = serviceLocator.mpsProject
+    private val mpsRepository: SRepository
+        get() = serviceLocator.mpsRepository
 
     var model: ReplicatedModel? = null
         private set
@@ -91,7 +91,7 @@ class BranchRegistry : InjectableService {
         this.client = client
 
         val repositoryChangeListener = RepositoryChangeListener(branch, serviceLocator)
-        mpsProject.repository.addRepositoryListener(repositoryChangeListener)
+        mpsRepository.addRepositoryListener(repositoryChangeListener)
         repoChangeListener = repositoryChangeListener
 
         return model!!
@@ -100,7 +100,7 @@ class BranchRegistry : InjectableService {
     override fun dispose() {
         val branch = getBranch() ?: return
         branch.removeListener(branchListener)
-        mpsProject.repository.removeRepositoryListener(repoChangeListener)
+        mpsRepository.removeRepositoryListener(repoChangeListener)
 
         model?.dispose()
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/util/ModuleDependencyConstants.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/util/ModuleDependencyConstants.kt
@@ -1,0 +1,7 @@
+package org.modelix.mps.sync.modelix.util
+
+import org.modelix.model.api.PropertyFromName
+
+object ModuleDependencyConstants {
+    val MODULE_DEPENDENCY_IS_READ_ONLY_PROPERTY = PropertyFromName("isReadOnly")
+}

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/factories/SNodeFactory.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/factories/SNodeFactory.kt
@@ -151,7 +151,8 @@ class SNodeFactory(
             } else {
                 // target node is an existing SNode
                 val area = MPSArea(mpsRepository)
-                val mpsNode = area.resolveNode(targetNodeReference) as MPSNode
+                val mpsNode = area.resolveNode(targetNodeReference) as MPSNode?
+                requireNotNull(mpsNode) { "SNode identified by Node $sourceNodeId is not found." }
                 source.setReferenceTarget(reference, mpsNode.node)
             }
         }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/factories/SNodeFactory.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/factories/SNodeFactory.kt
@@ -56,7 +56,7 @@ class SNodeFactory(
     private val nodeMap = serviceLocator.nodeMap
     private val syncQueue = serviceLocator.syncQueue
     private val futuresWaitQueue = serviceLocator.futuresWaitQueue
-    private val mpsRepository = serviceLocator.mpsProject.repository
+    private val mpsRepository = serviceLocator.mpsRepository
 
     private val resolvableReferences = mutableListOf<ResolvableReference>()
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/services/ServiceLocator.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/services/ServiceLocator.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
+import org.jetbrains.mps.openapi.module.SRepository
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.mps.sync.SyncServiceImpl
 import org.modelix.mps.sync.bindings.BindingsRegistry
@@ -40,6 +41,8 @@ class ServiceLocator(val project: Project) : Disposable {
     val futuresWaitQueue = FuturesWaitQueue()
 
     val mpsProject = project.toMpsProject()
+    val mpsRepository: SRepository
+        get() = mpsProject.repository
 
     val languageRepository = ApplicationManager.getApplication()
         .getService(MPSLanguageRepositoryProvider::class.java).mpsLanguageRepository

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMap.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMap.kt
@@ -66,9 +66,8 @@ class MpsToModelixMap : InjectableService {
     private val objectsRelatedToAModel = synchronizedMap<SModelReference, MutableSet<Any>>()
     private val objectsRelatedToAModule = synchronizedMap<SModuleReference, MutableSet<Any>>()
 
-    // TODO extract it to a new field in the serviceLocator so we do not have to repeat mpsProject.repository everywhere
     private val mpsRepository: SRepository
-        get() = serviceLocator.mpsProject.repository
+        get() = serviceLocator.mpsRepository
 
     private lateinit var serviceLocator: ServiceLocator
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMap.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMap.kt
@@ -20,11 +20,14 @@ import org.jetbrains.mps.openapi.model.SModel
 import org.jetbrains.mps.openapi.model.SModelId
 import org.jetbrains.mps.openapi.model.SModelReference
 import org.jetbrains.mps.openapi.model.SNode
+import org.jetbrains.mps.openapi.model.SNodeReference
 import org.jetbrains.mps.openapi.module.SModule
 import org.jetbrains.mps.openapi.module.SModuleId
 import org.jetbrains.mps.openapi.module.SModuleReference
+import org.jetbrains.mps.openapi.module.SRepository
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.mps.sync.mps.services.InjectableService
+import org.modelix.mps.sync.mps.services.ServiceLocator
 import org.modelix.mps.sync.util.synchronizedLinkedHashSet
 import org.modelix.mps.sync.util.synchronizedMap
 
@@ -32,7 +35,7 @@ import org.modelix.mps.sync.util.synchronizedMap
  * WARNING:
  * - use with caution, otherwise this cache may cause memory leaks
  * - if you add a new Map as a field in the class, then please also add it to the [remove], [isMappedToMps],
- * [isMappedToModelix], [isEmpty], [clear] methods below.
+ * [isMappedToModelix], [clear] methods below.
  * - if you want to persist the new field into a file, then add it to the [MpsToModelixMap.Serializer.serialize] and
  * [MpsToModelixMap.Serializer.deserialize] methods below.
  */
@@ -42,14 +45,14 @@ import org.modelix.mps.sync.util.synchronizedMap
 )
 class MpsToModelixMap : InjectableService {
 
-    private val nodeToModelixId = synchronizedMap<SNode, Long>()
-    private val modelixIdToNode = synchronizedMap<Long, SNode>()
+    private val nodeToModelixId = synchronizedMap<SNodeReference, Long>()
+    private val modelixIdToNode = synchronizedMap<Long, SNodeReference>()
 
-    private val modelToModelixId = synchronizedMap<SModel, Long>()
-    private val modelixIdToModel = synchronizedMap<Long, SModel>()
+    private val modelToModelixId = synchronizedMap<SModelReference, Long>()
+    private val modelixIdToModel = synchronizedMap<Long, SModelReference>()
 
-    private val moduleToModelixId = synchronizedMap<SModule, Long>()
-    private val modelixIdToModule = synchronizedMap<Long, SModule>()
+    private val moduleToModelixId = synchronizedMap<SModuleReference, Long>()
+    private val modelixIdToModule = synchronizedMap<Long, SModuleReference>()
 
     private val moduleWithOutgoingModuleReferenceToModelixId = synchronizedMap<ModuleWithModuleReference, Long>()
     private val modelixIdToModuleWithOutgoingModuleReference = synchronizedMap<Long, ModuleWithModuleReference>()
@@ -60,28 +63,41 @@ class MpsToModelixMap : InjectableService {
     private val modelWithOutgoingModelReferenceToModelixId = synchronizedMap<ModelWithModelReference, Long>()
     private val modelixIdToModelWithOutgoingModelReference = synchronizedMap<Long, ModelWithModelReference>()
 
-    private val objectsRelatedToAModel = synchronizedMap<SModel, MutableSet<Any>>()
-    private val objectsRelatedToAModule = synchronizedMap<SModule, MutableSet<Any>>()
+    private val objectsRelatedToAModel = synchronizedMap<SModelReference, MutableSet<Any>>()
+    private val objectsRelatedToAModule = synchronizedMap<SModuleReference, MutableSet<Any>>()
+
+    // TODO extract it to a new field in the serviceLocator so we do not have to repeat mpsProject.repository everywhere
+    private val mpsRepository: SRepository
+        get() = serviceLocator.mpsProject.repository
+
+    private lateinit var serviceLocator: ServiceLocator
+
+    override fun initService(serviceLocator: ServiceLocator) {
+        this.serviceLocator = serviceLocator
+    }
 
     fun put(node: SNode, modelixId: Long) {
-        nodeToModelixId[node] = modelixId
-        modelixIdToNode[modelixId] = node
+        val nodeReference = node.reference
+        nodeToModelixId[nodeReference] = modelixId
+        modelixIdToNode[modelixId] = nodeReference
 
-        node.model?.let { putObjRelatedToAModel(it, node) }
+        node.model?.let { putObjRelatedToAModel(it, nodeReference) }
     }
 
     fun put(model: SModel, modelixId: Long) {
-        modelToModelixId[model] = modelixId
-        modelixIdToModel[modelixId] = model
+        val modelReference = model.reference
+        modelToModelixId[modelReference] = modelixId
+        modelixIdToModel[modelixId] = modelReference
 
-        putObjRelatedToAModel(model, model)
+        putObjRelatedToAModel(model, modelReference)
     }
 
     fun put(module: SModule, modelixId: Long) {
-        moduleToModelixId[module] = modelixId
-        modelixIdToModule[modelixId] = module
+        val moduleReference = module.moduleReference
+        moduleToModelixId[moduleReference] = modelixId
+        modelixIdToModule[modelixId] = moduleReference
 
-        putObjRelatedToAModule(module, module)
+        putObjRelatedToAModule(module, moduleReference)
     }
 
     fun put(sourceModule: SModule, moduleReference: SModuleReference, modelixId: Long) {
@@ -108,23 +124,24 @@ class MpsToModelixMap : InjectableService {
         putObjRelatedToAModel(sourceModel, modelReference)
     }
 
-    private fun putObjRelatedToAModel(model: SModel, obj: Any?) {
-        objectsRelatedToAModel.computeIfAbsent(model) { synchronizedLinkedHashSet() }.add(obj!!)
+    private fun putObjRelatedToAModel(model: SModel, obj: Any) {
+        val modelReference = model.reference
+        objectsRelatedToAModel.computeIfAbsent(modelReference) { synchronizedLinkedHashSet() }.add(obj)
         // just in case, the model has not been tracked yet. E.g. @descriptor models that are created locally but were not synchronized to the model server.
-        putObjRelatedToAModule(model.module, model)
+        putObjRelatedToAModule(model.module, modelReference)
     }
 
-    private fun putObjRelatedToAModule(module: SModule, obj: Any?) =
-        objectsRelatedToAModule.computeIfAbsent(module) { synchronizedLinkedHashSet() }.add(obj!!)
+    private fun putObjRelatedToAModule(module: SModule, obj: Any) =
+        objectsRelatedToAModule.computeIfAbsent(module.moduleReference) { synchronizedLinkedHashSet() }.add(obj)
 
-    operator fun get(node: SNode?) = nodeToModelixId[node]
+    operator fun get(node: SNode?) = nodeToModelixId[node?.reference]
 
-    operator fun get(model: SModel?) = modelToModelixId[model]
+    operator fun get(model: SModel?) = modelToModelixId[model?.reference]
 
     operator fun get(modelId: SModelId?) =
         modelToModelixId.filter { it.key.modelId == modelId }.map { it.value }.firstOrNull()
 
-    operator fun get(module: SModule?) = moduleToModelixId[module]
+    operator fun get(module: SModule?) = moduleToModelixId[module?.moduleReference]
 
     operator fun get(moduleId: SModuleId?) =
         moduleToModelixId.filter { it.key.moduleId == moduleId }.map { it.value }.firstOrNull()
@@ -138,13 +155,14 @@ class MpsToModelixMap : InjectableService {
     operator fun get(sourceModel: SModel, modelReference: SModelReference) =
         modelWithOutgoingModelReferenceToModelixId[ModelWithModelReference(sourceModel, modelReference)]
 
-    fun getNode(modelixId: Long?) = modelixIdToNode[modelixId]
+    fun getNode(modelixId: Long?): SNode? = modelixIdToNode[modelixId]?.resolve(mpsRepository)
 
-    fun getModel(modelixId: Long?) = modelixIdToModel[modelixId]
+    fun getModel(modelixId: Long?): SModel? = modelixIdToModel[modelixId]?.resolve(mpsRepository)
 
-    fun getModule(modelixId: Long?) = modelixIdToModule[modelixId]
+    fun getModule(modelixId: Long?): SModule? = modelixIdToModule[modelixId]?.resolve(mpsRepository)
 
-    fun getModule(moduleId: SModuleId) = objectsRelatedToAModule.keys.firstOrNull { it.moduleId == moduleId }
+    fun getModule(moduleId: SModuleId): SModule? =
+        objectsRelatedToAModule.keys.firstOrNull { it.moduleId == moduleId }?.resolve(mpsRepository)
 
     fun getOutgoingModelReference(modelixId: Long?) = modelixIdToModelWithOutgoingModelReference[modelixId]
 
@@ -159,7 +177,9 @@ class MpsToModelixMap : InjectableService {
         // is related to model
         modelixIdToModel.remove(modelixId)?.let {
             modelToModelixId.remove(it)
-            remove(it)
+
+            val model = it.resolve(mpsRepository)
+            remove(model)
         }
         modelixIdToModelWithOutgoingModelReference.remove(modelixId)
             ?.let { modelWithOutgoingModelReferenceToModelixId.remove(it) }
@@ -167,14 +187,18 @@ class MpsToModelixMap : InjectableService {
             ?.let { modelWithOutgoingModuleReferenceToModelixId.remove(it) }
 
         // is related to module
-        modelixIdToModule.remove(modelixId)?.let { remove(it) }
+        modelixIdToModule.remove(modelixId)?.let {
+            val module = it.resolve(mpsRepository)!!
+            remove(module)
+        }
         modelixIdToModuleWithOutgoingModuleReference.remove(modelixId)
             ?.let { moduleWithOutgoingModuleReferenceToModelixId.remove(it) }
     }
 
     fun remove(model: SModel) {
-        modelToModelixId.remove(model)?.let { modelixIdToModel.remove(it) }
-        objectsRelatedToAModel.remove(model)?.forEach {
+        val reference = model.reference
+        modelToModelixId.remove(reference)?.let { modelixIdToModel.remove(it) }
+        objectsRelatedToAModel.remove(reference)?.forEach {
             when (it) {
                 is SModuleReference -> {
                     val target = ModelWithModuleReference(model, it)
@@ -188,7 +212,7 @@ class MpsToModelixMap : InjectableService {
                         ?.let { id -> modelixIdToModelWithOutgoingModelReference.remove(id) }
                 }
 
-                is SNode -> {
+                is SNodeReference -> {
                     nodeToModelixId.remove(it)?.let { modelixId -> modelixIdToNode.remove(modelixId) }
                 }
             }
@@ -196,14 +220,16 @@ class MpsToModelixMap : InjectableService {
     }
 
     fun remove(module: SModule) {
-        moduleToModelixId.remove(module)?.let { modelixIdToModule.remove(it) }
-        objectsRelatedToAModule.remove(module)?.forEach {
+        val reference = module.moduleReference
+        moduleToModelixId.remove(reference)?.let { modelixIdToModule.remove(it) }
+        objectsRelatedToAModule.remove(reference)?.forEach {
             if (it is SModuleReference) {
                 val target = ModuleWithModuleReference(module, it)
                 moduleWithOutgoingModuleReferenceToModelixId.remove(target)
                     ?.let { id -> modelixIdToModuleWithOutgoingModuleReference.remove(id) }
-            } else if (it is SModel) {
-                remove(it)
+            } else if (it is SModelReference) {
+                val model = it.resolve(mpsRepository)
+                remove(model)
             }
         }
     }
@@ -235,8 +261,6 @@ class MpsToModelixMap : InjectableService {
 
     fun isMappedToModelix(node: SNode) = this[node] != null
 
-    fun isEmpty() = objectsRelatedToAModel.isEmpty() && objectsRelatedToAModule.isEmpty()
-
     override fun dispose() {
         nodeToModelixId.clear()
         modelixIdToNode.clear()
@@ -259,16 +283,31 @@ class MpsToModelixMap : InjectableService {
     reason = "The new modelix MPS plugin is under construction",
     intendedFinalization = "This feature is finalized when the new sync plugin is ready for release.",
 )
-data class ModelWithModelReference(val source: SModel, val modelReference: SModelReference)
+data class ModelWithModelReference(
+    val sourceModelReference: SModelReference,
+    val modelReference: SModelReference,
+) {
+    constructor(source: SModel, modelReference: SModelReference) : this(source.reference, modelReference)
+}
 
 @UnstableModelixFeature(
     reason = "The new modelix MPS plugin is under construction",
     intendedFinalization = "This feature is finalized when the new sync plugin is ready for release.",
 )
-data class ModelWithModuleReference(val source: SModel, val moduleReference: SModuleReference)
+data class ModelWithModuleReference(
+    val sourceModelReference: SModelReference,
+    val moduleReference: SModuleReference,
+) {
+    constructor(source: SModel, moduleReference: SModuleReference) : this(source.reference, moduleReference)
+}
 
 @UnstableModelixFeature(
     reason = "The new modelix MPS plugin is under construction",
     intendedFinalization = "This feature is finalized when the new sync plugin is ready for release.",
 )
-data class ModuleWithModuleReference(val source: SModule, val moduleReference: SModuleReference)
+data class ModuleWithModuleReference(
+    val sourceModuleReference: SModuleReference,
+    val moduleReference: SModuleReference,
+) {
+    constructor(source: SModule, moduleReference: SModuleReference) : this(source.moduleReference, moduleReference)
+}

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMapInitializerVisitor.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMapInitializerVisitor.kt
@@ -10,6 +10,9 @@ import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.IBranch
 import org.modelix.model.api.INode
+import org.modelix.model.api.PNodeReference
+import org.modelix.model.mpsadapters.MPSArea
+import org.modelix.model.mpsadapters.MPSModelImportAsNode
 import org.modelix.mps.sync.modelix.tree.IBranchVisitor
 import org.modelix.mps.sync.modelix.util.getModel
 import org.modelix.mps.sync.modelix.util.getMpsNodeId
@@ -121,24 +124,39 @@ class MpsToModelixMapInitializerVisitor(
     }
 
     override suspend fun visitModelImport(sourceModel: INode, modelImport: INode) = runWithReadLocks {
+        val nodeId = modelImport.nodeIdAsLong()
         val model = getMpsModel(sourceModel)
         require(model is SModelBase) { "Model '${model.name}' (parent Module: ${model.module?.moduleName}) is not an SModelBase." }
 
-        val nodeId = modelImport.nodeIdAsLong()
-        val targetModel = modelImport.getReferenceTarget(BuiltinLanguages.MPSRepositoryConcepts.ModelReference.model)
-        val targetModelId = targetModel?.getPropertyValue(BuiltinLanguages.MPSRepositoryConcepts.Model.id)
-        requireNotNull(targetModelId) { "ID of Modelix Model referred by Modelix Model Import Node '$nodeId' is null." }
-        val modelId = PersistenceFacade.getInstance().createModelId(targetModelId)
+        val targetModelRef =
+            modelImport.getReferenceTargetRef(BuiltinLanguages.MPSRepositoryConcepts.ModelReference.model)!!
+        val serializedModelRef = targetModelRef.serialize()
 
-        if (model.modelId == modelId) {
+        val targetIsAnINode = PNodeReference.tryDeserialize(serializedModelRef) != null
+        val (targetModelId, targetModelName) = if (targetIsAnINode) {
+            val targetModel =
+                modelImport.getReferenceTarget(BuiltinLanguages.MPSRepositoryConcepts.ModelReference.model)
+            val targetModelId = targetModel?.getPropertyValue(BuiltinLanguages.MPSRepositoryConcepts.Model.id)
+            requireNotNull(targetModelId) { "ID of Modelix Model referred by Modelix Model Import Node '$nodeId' is null." }
+            val modelId = PersistenceFacade.getInstance().createModelId(targetModelId)
+            val modelName = targetModel.getPropertyValue(BuiltinLanguages.jetbrains_mps_lang_core.INamedConcept.name)
+            Pair(modelId, modelName)
+        } else {
+            // target is an SModel in MPS
+            val modelixModelImport = MPSArea(repository).resolveNode(targetModelRef) as MPSModelImportAsNode
+            val targetModel = modelixModelImport.importedModel
+            val modelId = targetModel.modelId
+            val modelName = targetModel.name
+            Pair(modelId, modelName)
+        }
+
+        if (model.modelId == targetModelId) {
             logger.warn { "Ignoring Model Import from Model ${model.name} (parent Module: ${model.module?.moduleName}) to itself." }
             return@runWithReadLocks
         }
 
-        val targetModelImport = model.modelImports.firstOrNull { it.modelId == modelId }
+        val targetModelImport = model.modelImports.firstOrNull { it.modelId == targetModelId }
         requireNotNull(targetModelImport) {
-            val targetModelName =
-                targetModel.getPropertyValue(BuiltinLanguages.jetbrains_mps_lang_core.INamedConcept.name)
             "Model '${model.name}' (parent Module: ${model.module?.moduleName}) has no Model Import with ID '$targetModelId' and name '$targetModelName'."
         }
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMapInitializerVisitor.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMapInitializerVisitor.kt
@@ -143,7 +143,8 @@ class MpsToModelixMapInitializerVisitor(
             Pair(modelId, modelName)
         } else {
             // target is an SModel in MPS
-            val modelixModelImport = MPSArea(repository).resolveNode(targetModelRef) as MPSModelImportAsNode
+            val modelixModelImport = MPSArea(repository).resolveNode(targetModelRef) as MPSModelImportAsNode?
+            requireNotNull(modelixModelImport) { "Model Import identified by Node $modelImport is not found." }
             val targetModel = modelixModelImport.importedModel
             val modelId = targetModel.modelId
             val modelName = targetModel.name

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/incremental/ModelixTreeChangeVisitor.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/incremental/ModelixTreeChangeVisitor.kt
@@ -203,8 +203,8 @@ class ModelixTreeChangeVisitor(
                 return@enqueue null
             }
 
-            val message = "A removal case for Node ($nodeId) was missed."
-            notifyAndLogError(message)
+            val message = "A removal case for Node ($nodeId) was missed. It can be ignored, if the Node's parent is deleted."
+            notifier.notifyAndLogWarning(message, logger)
 
             null
         }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/incremental/ModelixTreeChangeVisitor.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/incremental/ModelixTreeChangeVisitor.kt
@@ -58,7 +58,7 @@ class ModelixTreeChangeVisitor(
     private val nodeMap = serviceLocator.nodeMap
     private val syncQueue = serviceLocator.syncQueue
     private val notifier = serviceLocator.wrappedNotifier
-    private val mpsRepository = serviceLocator.mpsProject.repository
+    private val mpsRepository = serviceLocator.mpsRepository
 
     private val nodeTransformer = NodeTransformer(branch, serviceLocator, languageRepository)
     private val modelTransformer = ModelTransformer(branch, serviceLocator, languageRepository)

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/incremental/ModelixTreeChangeVisitor.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/incremental/ModelixTreeChangeVisitor.kt
@@ -104,7 +104,8 @@ class ModelixTreeChangeVisitor(
                         nodeMap.getNode(targetNode.nodeIdAsLong())
                     } else {
                         val area = MPSArea(mpsRepository)
-                        val mpsNode = area.resolveNode(targetNodeReference) as MPSNode
+                        val mpsNode = area.resolveNode(targetNodeReference) as MPSNode?
+                        requireNotNull(mpsNode) { "SNode identified by Node $nodeId is not found." }
                         mpsNode.node
                     }
                 }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
@@ -76,10 +76,11 @@ class ModelTransformer(
     private val nodeMap = serviceLocator.nodeMap
     private val syncQueue = serviceLocator.syncQueue
     private val futuresWaitQueue = serviceLocator.futuresWaitQueue
-    private val mpsRepository = serviceLocator.mpsProject.repository
 
     private val notifier = serviceLocator.wrappedNotifier
+
     private val mpsProject = serviceLocator.mpsProject
+    private val mpsRepository = serviceLocator.mpsRepository
 
     private val nodeTransformer = NodeTransformer(branch, serviceLocator, mpsLanguageRepository)
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
@@ -178,7 +178,8 @@ class ModelTransformer(
                 )
             } else {
                 // target is an SModel in MPS
-                val modelixModelImport = MPSArea(mpsRepository).resolveNode(targetModelRef) as MPSModelImportAsNode
+                val modelixModelImport = MPSArea(mpsRepository).resolveNode(targetModelRef) as MPSModelImportAsNode?
+                requireNotNull(modelixModelImport) { "Model Import identified by Node $nodeId is not found." }
                 val modelImport = modelixModelImport.importedModel.reference
                 ModelImports(sourceModel).addModelImport(modelImport)
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
@@ -329,6 +329,7 @@ class ModelTransformer(
     fun modeImportDeleted(outgoingModelReference: ModelWithModelReference) {
         val model = outgoingModelReference.sourceModelReference.resolve(mpsRepository)
         ModelImports(model).removeModelImport(outgoingModelReference.modelReference)
+        nodeMap.remove(outgoingModelReference)
     }
 
     fun moduleDependencyOfModelDeleted(modelWithModuleReference: ModelWithModuleReference, nodeId: Long) {
@@ -339,6 +340,7 @@ class ModelTransformer(
                 try {
                     val sLanguage = MetaAdapterFactory.getLanguage(targetModuleReference)
                     sourceModel.deleteLanguage(sLanguage)
+                    nodeMap.remove(modelWithModuleReference)
                 } catch (ex: Exception) {
                     val message =
                         "Language Import ($targetModule) cannot be deleted, because ${ex.message} Corresponding Node ID is $nodeId."
@@ -349,6 +351,7 @@ class ModelTransformer(
             is DevKit -> {
                 try {
                     sourceModel.deleteDevKit(targetModuleReference)
+                    nodeMap.remove(modelWithModuleReference)
                 } catch (ex: Exception) {
                     val message =
                         "DevKit dependency ($targetModule) cannot be deleted, because ${ex.message} Corresponding Node ID is $nodeId."

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
@@ -179,7 +179,10 @@ class ModelTransformer(
             } else {
                 // target is an SModel in MPS
                 val modelixModelImport = MPSArea(mpsRepository).resolveNode(targetModelRef) as MPSModelImportAsNode
-                ModelImports(sourceModel).addModelImport(modelixModelImport.importedModel.reference)
+                val modelImport = modelixModelImport.importedModel.reference
+                ModelImports(sourceModel).addModelImport(modelImport)
+
+                nodeMap.put(sourceModel, modelImport, iNode.nodeIdAsLong())
             }
         }
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
@@ -101,7 +101,7 @@ class ModelTransformer(
                     .waitForCompletionOfEachTask(futuresWaitQueue) {
                         nodeTransformer.transformLanguageOrDevKitDependency(it)
                     }
-            }.continueWith(linkedSetOf(SyncLock.MODELIX_READ), SyncDirection.MODELIX_TO_MPS) {
+            }.continueWith(linkedSetOf(SyncLock.MODELIX_READ, SyncLock.MPS_READ), SyncDirection.MODELIX_TO_MPS) {
                 val iNode = branch.getNode(nodeId)
                 if (isDescriptorModel(iNode)) {
                     EmptyBinding()
@@ -323,11 +323,12 @@ class ModelTransformer(
     }
 
     fun modeImportDeleted(outgoingModelReference: ModelWithModelReference) {
-        ModelImports(outgoingModelReference.source).removeModelImport(outgoingModelReference.modelReference)
+        val model = outgoingModelReference.sourceModelReference.resolve(mpsRepository)
+        ModelImports(model).removeModelImport(outgoingModelReference.modelReference)
     }
 
     fun moduleDependencyOfModelDeleted(modelWithModuleReference: ModelWithModuleReference, nodeId: Long) {
-        val sourceModel = modelWithModuleReference.source
+        val sourceModel = modelWithModuleReference.sourceModelReference.resolve(mpsRepository)
         val targetModuleReference = modelWithModuleReference.moduleReference
         when (val targetModule = targetModuleReference.resolve(sourceModel.repository)) {
             is Language -> {

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModuleTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModuleTransformer.kt
@@ -111,7 +111,7 @@ class ModuleTransformer(
                     modelTransformer.resolveCrossModelReferences(mpsProject.repository)
                 }
                 flattenedBindings
-            }.continueWith(linkedSetOf(SyncLock.NONE), SyncDirection.MODELIX_TO_MPS) { dependencyAndModelBindings ->
+            }.continueWith(linkedSetOf(SyncLock.MPS_READ), SyncDirection.MODELIX_TO_MPS) { dependencyAndModelBindings ->
                 // register binding
                 val iNode = branch.getNode(nodeId)
                 val module = nodeMap.getModule(iNode.nodeIdAsLong()) as AbstractModule
@@ -318,7 +318,7 @@ class ModuleTransformer(
     }
 
     fun outgoingModuleReferenceFromModuleDeleted(moduleWithModuleReference: ModuleWithModuleReference, nodeId: Long) {
-        val sourceModule = moduleWithModuleReference.source
+        val sourceModule = moduleWithModuleReference.sourceModuleReference.resolve(mpsProject.repository)
         if (sourceModule !is AbstractModule) {
             val message =
                 "Source Module ($sourceModule) is not an AbstractModule, therefore the outgoing Module Dependency reference cannot be removed. Corresponding Node ID is $nodeId."

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModuleTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModuleTransformer.kt
@@ -78,6 +78,7 @@ class ModuleTransformer(
     private val bindingsRegistry = serviceLocator.bindingsRegistry
     private val notifier = serviceLocator.wrappedNotifier
     private val mpsProject = serviceLocator.mpsProject
+    private val mpsRepository = serviceLocator.mpsRepository
 
     private val solutionProducer = SolutionProducer(mpsProject)
 
@@ -108,7 +109,7 @@ class ModuleTransformer(
                 // resolve references only after all dependent (and contained) modules and models have been transformed
                 if (isTransformationStartingModule) {
                     // resolve cross-model references (and node references)
-                    modelTransformer.resolveCrossModelReferences(mpsProject.repository)
+                    modelTransformer.resolveCrossModelReferences(mpsRepository)
                 }
                 flattenedBindings
             }.continueWith(linkedSetOf(SyncLock.MPS_READ), SyncDirection.MODELIX_TO_MPS) { dependencyAndModelBindings ->
@@ -318,7 +319,7 @@ class ModuleTransformer(
     }
 
     fun outgoingModuleReferenceFromModuleDeleted(moduleWithModuleReference: ModuleWithModuleReference, nodeId: Long) {
-        val sourceModule = moduleWithModuleReference.sourceModuleReference.resolve(mpsProject.repository)
+        val sourceModule = moduleWithModuleReference.sourceModuleReference.resolve(mpsRepository)
         if (sourceModule !is AbstractModule) {
             val message =
                 "Source Module ($sourceModule) is not an AbstractModule, therefore the outgoing Module Dependency reference cannot be removed. Corresponding Node ID is $nodeId."

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModuleTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModuleTransformer.kt
@@ -332,6 +332,7 @@ class ModuleTransformer(
             sourceModule.moduleDescriptor?.dependencies?.firstOrNull { it.moduleRef == targetModuleReference }
         if (dependency != null) {
             sourceModule.removeDependency(dependency)
+            nodeMap.remove(moduleWithModuleReference)
         } else {
             val message =
                 "Outgoing dependency $targetModuleReference from Module $sourceModule is not found, therefore it cannot be deleted. Corresponding Node ID is $nodeId."

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/NodeTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/NodeTransformer.kt
@@ -65,7 +65,7 @@ class NodeTransformer(
     private val syncQueue = serviceLocator.syncQueue
 
     private val notifier = serviceLocator.wrappedNotifier
-    private val mpsRepository = serviceLocator.mpsProject.repository
+    private val mpsRepository = serviceLocator.mpsRepository
 
     private val nodeFactory = SNodeFactory(mpsLanguageRepository, branch, serviceLocator)
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/NodeTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/NodeTransformer.kt
@@ -83,7 +83,7 @@ class NodeTransformer(
     fun transformNode(
         nodeId: Long,
         nodeFactoryMethod: KFunction2<Long, SModel?, ContinuableSyncTask> = nodeFactory::createNode,
-    ) = syncQueue.enqueue(linkedSetOf(SyncLock.MODELIX_READ), SyncDirection.MODELIX_TO_MPS) {
+    ) = syncQueue.enqueue(linkedSetOf(SyncLock.MODELIX_READ, SyncLock.MPS_READ), SyncDirection.MODELIX_TO_MPS) {
         val iNode = branch.getNode(nodeId)
         val modelId = iNode.getModel()?.nodeIdAsLong()
         val model = nodeMap.getModel(modelId)

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModelChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModelChangeListener.kt
@@ -32,6 +32,8 @@ import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.IBranch
 import org.modelix.mps.sync.bindings.ModelBinding
 import org.modelix.mps.sync.mps.services.ServiceLocator
+import org.modelix.mps.sync.tasks.SyncDirection
+import org.modelix.mps.sync.tasks.SyncLock
 import org.modelix.mps.sync.transformation.mpsToModelix.initial.ModelSynchronizer
 import org.modelix.mps.sync.transformation.mpsToModelix.initial.NodeSynchronizer
 
@@ -52,6 +54,7 @@ class ModelChangeListener(
 
     override fun importAdded(event: SModelImportEvent) {
         modelSynchronizer.addModelImport(event.model, event.modelUID)
+            .continueWith(linkedSetOf(SyncLock.NONE), SyncDirection.NONE) { resolveModelImports().getResult() }
     }
 
     override fun importRemoved(event: SModelImportEvent) {

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/NodeChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/NodeChangeListener.kt
@@ -58,10 +58,6 @@ class NodeChangeListener(branch: IBranch, serviceLocator: ServiceLocator) : SNod
 
     override fun referenceChanged(event: SReferenceChangeEvent) {
         // TODO fix me: it does not work correctly, if event.newValue.targetNode points to a node that is in a different model, that has not been synced yet to model server...
-        synchronizer.setReference(
-            event.associationLink,
-            sourceNodeIdProducer = { it[event.node]!! },
-            targetNodeIdProducer = { nodesMap -> event.newValue?.targetNode?.let { nodesMap[it] } },
-        )
+        synchronizer.setReference(event.associationLink, event.node, event.newValue?.targetNode)
     }
 }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
@@ -26,6 +26,7 @@ import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.IBranch
 import org.modelix.model.api.INode
+import org.modelix.model.api.NodeReference
 import org.modelix.model.api.getNode
 import org.modelix.model.mpsadapters.MPSModelImportReference
 import org.modelix.mps.sync.IBinding
@@ -208,7 +209,8 @@ class ModelSynchronizer(
         nodeMap.put(source, targetModel.reference, cloudModelReference.nodeIdAsLong())
 
         if (targetModel.isReadOnly) {
-            cloudModelReference.setReferenceTarget(targetModelReference, MPSModelImportReference(targetModel.reference, source.reference))
+            val serialized = MPSModelImportReference(targetModel.reference, source.reference).serialize()
+            cloudModelReference.setReferenceTarget(targetModelReference, NodeReference(serialized))
         } else {
             cloudModelReference.setReferenceTarget(targetModelReference, cloudTargetModel)
         }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
@@ -188,7 +188,7 @@ class ModelSynchronizer(
         }
 
     private fun addReadOnlyModelImportToCloud(source: SModel, targetModel: SModel) {
-        val modelixId = nodeMap[source]!!
+        val modelixId = requireNotNull(nodeMap[source]) { "SModel '$source' is not found in the synchronization map." }
         val cloudParentNode = branch.getNode(modelixId)
         val childLink = BuiltinLanguages.MPSRepositoryConcepts.Model.modelImports
 
@@ -218,7 +218,7 @@ class ModelSynchronizer(
     }
 
     private fun addNormalModelImportToCloud(source: SModel, targetModel: SModel) {
-        val modelixId = nodeMap[source]!!
+        val modelixId = requireNotNull(nodeMap[source]) { "SModel '$source' is not found in the synchronization map." }
         val cloudParentNode = branch.getNode(modelixId)
         val childLink = BuiltinLanguages.MPSRepositoryConcepts.Model.modelImports
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
@@ -27,6 +27,7 @@ import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.IBranch
 import org.modelix.model.api.INode
 import org.modelix.model.api.getNode
+import org.modelix.model.mpsadapters.MPSModelImportReference
 import org.modelix.mps.sync.IBinding
 import org.modelix.mps.sync.bindings.EmptyBinding
 import org.modelix.mps.sync.bindings.ModelBinding
@@ -200,13 +201,17 @@ class ModelSynchronizer(
             return
         }
 
+        // warning: might be fragile, because we synchronize the ModelReference's fields by hand
         val cloudModelReference =
             cloudParentNode.addNewChild(childLink, -1, BuiltinLanguages.MPSRepositoryConcepts.ModelReference)
 
         nodeMap.put(source, targetModel.reference, cloudModelReference.nodeIdAsLong())
 
-        // warning: might be fragile, because we synchronize the fields by hand
-        cloudModelReference.setReferenceTarget(targetModelReference, cloudTargetModel)
+        if (targetModel.isReadOnly) {
+            cloudModelReference.setReferenceTarget(targetModelReference, MPSModelImportReference(targetModel.reference, source.reference))
+        } else {
+            cloudModelReference.setReferenceTarget(targetModelReference, cloudTargetModel)
+        }
     }
 
     fun addLanguageDependency(model: SModel, language: SLanguage) =

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
@@ -180,7 +180,44 @@ class ModelSynchronizer(
             }
         }
 
-    private fun addModelImportToCloud(source: SModel, targetModel: SModel) {
+    private fun addModelImportToCloud(source: SModel, targetModel: SModel) =
+        if (targetModel.isReadOnly) {
+            addReadOnlyModelImportToCloud(source, targetModel)
+        } else {
+            addNormalModelImportToCloud(source, targetModel)
+        }
+
+    private fun addReadOnlyModelImportToCloud(source: SModel, targetModel: SModel) {
+        val modelixId = nodeMap[source]!!
+        val cloudParentNode = branch.getNode(modelixId)
+        val childLink = BuiltinLanguages.MPSRepositoryConcepts.Model.modelImports
+
+        val targetModelReference = BuiltinLanguages.MPSRepositoryConcepts.ModelReference.model
+        val serialized = MPSModelImportReference(targetModel.reference, source.reference).serialize()
+        val targetModelNodeReference = NodeReference(serialized)
+
+        // duplicate check and sync
+        val modelImportExists = cloudParentNode.getChildren(childLink).any {
+            val targetRef = it.getReferenceTargetRef(targetModelReference)
+            targetRef is NodeReference && targetRef.serialized == targetModelNodeReference.serialized
+        }
+        if (modelImportExists) {
+            val message =
+                "Model Import for Model '${targetModel.name}' from Model '${source.name}' will not be synchronized, because it already exists on the server."
+            notifier.notifyAndLogWarning(message, logger)
+            return
+        }
+
+        // warning: might be fragile, because we synchronize the ModelReference's fields by hand
+        val cloudModelReference =
+            cloudParentNode.addNewChild(childLink, -1, BuiltinLanguages.MPSRepositoryConcepts.ModelReference)
+
+        nodeMap.put(source, targetModel.reference, cloudModelReference.nodeIdAsLong())
+
+        cloudModelReference.setReferenceTarget(targetModelReference, targetModelNodeReference)
+    }
+
+    private fun addNormalModelImportToCloud(source: SModel, targetModel: SModel) {
         val modelixId = nodeMap[source]!!
         val cloudParentNode = branch.getNode(modelixId)
         val childLink = BuiltinLanguages.MPSRepositoryConcepts.Model.modelImports
@@ -208,12 +245,7 @@ class ModelSynchronizer(
 
         nodeMap.put(source, targetModel.reference, cloudModelReference.nodeIdAsLong())
 
-        if (targetModel.isReadOnly) {
-            val serialized = MPSModelImportReference(targetModel.reference, source.reference).serialize()
-            cloudModelReference.setReferenceTarget(targetModelReference, NodeReference(serialized))
-        } else {
-            cloudModelReference.setReferenceTarget(targetModelReference, cloudTargetModel)
-        }
+        cloudModelReference.setReferenceTarget(targetModelReference, cloudTargetModel)
     }
 
     fun addLanguageDependency(model: SModel, language: SLanguage) =

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
@@ -342,8 +342,15 @@ class ModelSynchronizer(
     }
 
     private fun resolveModelImports() {
-        resolvableModelImports.forEach { addModelImportToCloud(it.sourceModel, it.targetModel) }
-        resolvableModelImports.clear()
+        resolvableModelImports.forEach {
+            try {
+                addModelImportToCloud(it.sourceModel, it.targetModel)
+                it.isResolved = true
+            } catch (ex: Exception) {
+                it.isResolved = false
+            }
+        }
+        resolvableModelImports.removeIf { it.isResolved }
     }
 
     private fun notifyAndLogError(message: String) {
@@ -359,4 +366,5 @@ class ModelSynchronizer(
 data class CloudResolvableModelImport(
     val sourceModel: SModel,
     val targetModel: SModel,
+    var isResolved: Boolean = false,
 )

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
@@ -62,7 +62,7 @@ class ModuleSynchronizer(private val branch: IBranch, private val serviceLocator
 
     private val bindingsRegistry = serviceLocator.bindingsRegistry
     private val notifier = serviceLocator.wrappedNotifier
-    private val mpsRepository = serviceLocator.mpsProject.repository
+    private val mpsRepository = serviceLocator.mpsRepository
 
     private val modelSynchronizer = ModelSynchronizer(branch, serviceLocator, true)
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
@@ -148,12 +148,10 @@ class ModuleSynchronizer(private val branch: IBranch, private val serviceLocator
         syncQueue.enqueue(linkedSetOf(SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX) {
             val targetModule = dependency.targetModule.resolve(mpsRepository)
             requireNotNull(targetModule) { "Outgoing Dependency '${dependency.targetModule.moduleName}' of Module '${module.moduleName}' is not found." }
-
             val isMappedToMps = nodeMap[targetModule] != null
-            val targetModuleIsReadOnly = targetModule.isReadOnly
 
             // add the target module to the server if it does not exist there yet, and if it is not read-only
-            if (!isMappedToMps && !targetModuleIsReadOnly) {
+            if (!isMappedToMps && !targetModule.isReadOnly) {
                 require(targetModule is AbstractModule) {
                     val message =
                         "Dependency ($dependency)'s target Module ($targetModule) must be an AbstractModule. Dependency's source Module is ($module)."

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
@@ -146,7 +146,9 @@ class ModuleSynchronizer(private val branch: IBranch, private val serviceLocator
 
     fun addDependency(module: SModule, dependency: SDependency) =
         syncQueue.enqueue(linkedSetOf(SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX) {
-            val targetModule = dependency.targetModule.resolve(mpsRepository)!!
+            val targetModule = dependency.targetModule.resolve(mpsRepository)
+            requireNotNull(targetModule) { "Outgoing Dependency '${dependency.targetModule.moduleName}' of Module '${module.moduleName}' is not found." }
+
             val isMappedToMps = nodeMap[targetModule] != null
             val targetModuleIsReadOnly = targetModule.isReadOnly
 
@@ -231,7 +233,8 @@ class ModuleSynchronizer(private val branch: IBranch, private val serviceLocator
                 dependency.scope.toString(),
             )
 
-            val targetModule = moduleReference.resolve(mpsRepository)!!
+            val targetModule = moduleReference.resolve(mpsRepository)
+            requireNotNull(targetModule) { "Outgoing Dependency '${dependency.targetModule.moduleName}' of Module '${module.moduleName}' is not found." }
             cloudDependency.setPropertyValue(
                 ModuleDependencyConstants.MODULE_DEPENDENCY_IS_READ_ONLY_PROPERTY,
                 targetModule.isReadOnly.toString(),

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/NodeSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/NodeSynchronizer.kt
@@ -26,6 +26,7 @@ import org.modelix.model.api.IChildLink
 import org.modelix.model.api.INode
 import org.modelix.model.api.IProperty
 import org.modelix.model.api.IReferenceLink
+import org.modelix.model.api.NodeReference
 import org.modelix.model.api.PropertyFromName
 import org.modelix.model.api.getNode
 import org.modelix.model.data.NodeData
@@ -140,7 +141,8 @@ class NodeSynchronizer(
         if (mpsTargetNode == null) {
             cloudNode.setReferenceTarget(modelixReferenceLink, null as INode?)
         } else if (mpsTargetNode.model?.isReadOnly == true) {
-            val nodeReference = MPSNodeReference(mpsTargetNode.reference)
+            val serialized = MPSNodeReference(mpsTargetNode.reference).serialize()
+            val nodeReference = NodeReference(serialized)
             cloudNode.setReferenceTarget(modelixReferenceLink, nodeReference)
         } else {
             val targetNodeId = nodeMap[mpsTargetNode]!!

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/NodeSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/NodeSynchronizer.kt
@@ -171,17 +171,25 @@ class NodeSynchronizer(
 
     fun setReference(
         mpsReferenceLink: SReferenceLink,
-        sourceNodeIdProducer: (MpsToModelixMap) -> Long,
-        targetNodeIdProducer: (MpsToModelixMap) -> Long?,
+        sourceNode: SNode,
+        targetNode: SNode?,
     ) {
         syncQueue.enqueue(linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX) {
-            val sourceNodeId = sourceNodeIdProducer.invoke(nodeMap)
-            val targetNodeId = targetNodeIdProducer.invoke(nodeMap)
+            val sourceNodeId = nodeMap[sourceNode]!!
+            val cloudNode = branch.getNode(sourceNodeId)
             val reference = MPSReferenceLink(mpsReferenceLink)
 
-            val cloudNode = branch.getNode(sourceNodeId)
-            val target = if (targetNodeId == null) null else branch.getNode(targetNodeId)
-            cloudNode.setReferenceTarget(reference, target)
+            if (targetNode == null) {
+                cloudNode.setReferenceTarget(reference, null as INode?)
+            } else if (targetNode.model?.isReadOnly == true) {
+                val serialized = MPSNodeReference(targetNode.reference).serialize()
+                val nodeReference = NodeReference(serialized)
+                cloudNode.setReferenceTarget(reference, nodeReference)
+            } else {
+                val targetNodeId = nodeMap[targetNode]!!
+                val targetModelixNode = branch.getNode(targetNodeId)
+                cloudNode.setReferenceTarget(reference, targetModelixNode)
+            }
         }
     }
 

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/ModelSyncAction.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/ModelSyncAction.kt
@@ -39,6 +39,7 @@ object ModelSyncAction : AnAction("Synchronize Model to Server") {
         actionPerformedSafely(event, logger, "Model synchronization error occurred.") { serviceLocator ->
             val model = event.getData(contextModel) as? SModelBase
             checkNotNull(model) { "Synchronization is not possible, because Model (${model?.name}) is not an SModelBase." }
+            check(!model.isReadOnly) { "Synchronization action is not allowed on read-only Model (${model.name})." }
 
             val branchRegistry = serviceLocator.branchRegistry
             val branch = branchRegistry.getBranch()

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/ModuleSyncAction.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/ModuleSyncAction.kt
@@ -39,6 +39,7 @@ object ModuleSyncAction : AnAction("Synchronize Module to Server") {
         actionPerformedSafely(event, logger, "Module synchronization error occurred.") { serviceLocator ->
             val module = event.getData(contextModule) as? AbstractModule
             checkNotNull(module) { "Synchronization is not possible, because Module (${module?.moduleName}) is not an AbstractModule." }
+            check(!module.isReadOnly) { "Synchronization action is not allowed on read-only Module (${module.moduleName})." }
 
             val branchRegistry = serviceLocator.branchRegistry
             val branch = branchRegistry.getBranch()

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/UnbindModelAction.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/UnbindModelAction.kt
@@ -39,6 +39,7 @@ object UnbindModelAction : AnAction("Unbind Model") {
         actionPerformedSafely(event, logger, "Model unbind error occurred.") { serviceLocator ->
             val model = event.getData(contextModel) as? SModelBase
             checkNotNull(model) { "Unbinding is not possible, because Model (${model?.name}) is not an SModelBase." }
+            check(!model.isReadOnly) { "Unbinding is not possible, because Model (${model.name}) is read-only." }
 
             val bindingsRegistry = serviceLocator.bindingsRegistry
             val binding = bindingsRegistry.getModelBinding(model)

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/UnbindModuleAction.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/UnbindModuleAction.kt
@@ -39,6 +39,7 @@ object UnbindModuleAction : AnAction("Unbind Module") {
         actionPerformedSafely(event, logger, "Module unbind error occurred.") { serviceLocator ->
             val module = event.getData(contextModule) as? AbstractModule
             checkNotNull(module) { "Unbinding is not possible, because Module (${module?.moduleName}) is not an AbstractModule." }
+            check(!module.isReadOnly) { "Unbinding is not possible, because Module (${module.moduleName}) is read-only." }
 
             val bindingsRegistry = serviceLocator.bindingsRegistry
             val binding = bindingsRegistry.getModuleBinding(module)


### PR DESCRIPTION
In the followings, the term "cloud" can be interchangeably used with "modelix model server".

# Problem

Sometimes our users would like to refer to SNodes in their models, which are not part of their Project, but are coming from SModels in pre-installed plugins.

So far such referred SNodes were synched to the cloud with their full structure (properties, refereces, and their children recursively). Moreover, their parent SModel / SModules were also synched to the cloud completely (including all model imports, module dependencies, language dependencies, content, etc). Synching all those elements recursively to the cloud is an exhaustive task, especially if the transitive Module Dependencies are built in a way, that basically the whole application has to be synched.

As an example, imagine an MPS-based application, where the user just includes the root SModule in a DevKit (that are coming from pre-installed plugins) and this root SModule transitively includes all sub-modules the application is composed of. If the user puts a Module Dependency or a DevKit dependency for this SModule inside their Project, then all SModules will be synched to the cloud, which can be very exhaustive.

# Solution

Since the aformentioned SNodes, SModels and SModules are coming from pre-installed plugins, they are read-only by default (thanks to MPS). It means, that since their structure cannot be changed, we do not have to replicate them in the cloud, but we could just save some "special references" (c.f. [MPSNodeReference](https://github.com/modelix/modelix.core/blob/main/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSReferences.kt#L48), [MPSModelImportReference](https://github.com/modelix/modelix.core/blob/main/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSReferences.kt#L102)) for them which say that these elements are in MPS and we persist their MPS-based references in the cloud. It means, that when those elements are downloaded from the cloud, then we just resolve them locally in MPS, because we assume that they exist (since they are coming from the pre-installed plugins).

It simplifies the implementation a lot as we can see in the followings:

## References for read-only SNodes

If an SNode 'A' refers to a read-only SNode 'B', then we [create a serialized MPSNodeReference](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-84e75bc9d930320341232d30f05925f2437acfb7a6272e6c7f1fa3d781f27dbeR144), which includes the MPS-based node reference (identifier). We put this serialized reference [in a NodeReference](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-84e75bc9d930320341232d30f05925f2437acfb7a6272e6c7f1fa3d781f27dbeR145), that is used as the [Reference Target](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-84e75bc9d930320341232d30f05925f2437acfb7a6272e6c7f1fa3d781f27dbeR146) in the cloud.

When such reference arrives from the cloud, then we decide if the serialized reference refers to an INode (because INode references can be also serialized) or to an MPS-node. If it refers to an INode, then we fetch that node and transform it to an SNode (just like before). If it refers to an MPS-node, then we resolve that node locally in MPS. (For details see lines [94-111 in ModelixTreeChangeVisitor](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-7ddf1a46c90ead95ca3d935fe370edb5baffcd8df6895ea1c8da93288bee7b18R94).)

## Model imports for read-only SModels

If an SModel 'C' imports a read-only SModel 'D', then we [create a serialized MPSModelImportReference](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-e4cdbf7d793f7249a792cf4aec414635711caa31b4929872413c7c0ff1fbf87cR196), which includes the MPS-based model reference (identifier). We put this serialized reference [in a NodeReference](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-e4cdbf7d793f7249a792cf4aec414635711caa31b4929872413c7c0ff1fbf87cR197), that is used as the [Reference Target](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-e4cdbf7d793f7249a792cf4aec414635711caa31b4929872413c7c0ff1fbf87cR217) in the cloud.

When such model import arrives from the cloud, then we decide if the serialized reference refers to an INode or to an SModel in MPS. If it refers to an INode, then we fetch that node and create a ResolvableModelImport from it (because the referred model might not have been transformed yet; just like before). If it refers to an SModel in MPS, then we resolve that SModel locally. For details see [lines 163-186 in ModelTransformer](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-bf404f9627828fe121042d1cc9a168e0da120e725b4caab90386b8f0a9ad2c43R163).

## Module dependencies for read-only SModules

If an SModule 'E' puts a dependency on a read-only SModule 'F', then not too much changes. Read-only SModules will not be transformed to INodes (see [lines 149-154 in ModuleSynchronizer](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-1ab9f4e3a17d7e1d512a3be17d2a5dad289ce3fc7a2d279a5d2d370158f467f4R149)), but only the ModuleDependency will be created. The ModuleDependency has a UUID field which contains the UUID of the read-only SModule. There is an extra [`isReadOnly` property](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-30187284ff3c225cf0fb8f541976d5ec2a35da76a62c1e7bc510ebbf18b4b8e3R6) in the ModuleDependency, [that is set to true](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-1ab9f4e3a17d7e1d512a3be17d2a5dad289ce3fc7a2d279a5d2d370158f467f4R237) if the target SModule ('F') is read-only.

Note that the `isReadOnly` property is an extra, that is not part of the original [ModuleDependency](https://github.com/modelix/modelix.core/blob/main/model-api/src/commonMain/kotlin/org/modelix/model/api/BuiltinLanguages.kt#L396) Concept definition. However, it does not cause any problems, even if someone uses the generated API for this Concept. That's because the generated API ignores those properties and references that are not part of the definition and can therefore transform the INode to TypedNode (N_ModuleDependency), even if it has some extra properties in its property store.

When such module dependency arrives from the cloud, then we check if its `isReadOnly` property is true. If it is true, then we do not try to transform the target module from INode to SModule, because we know that it must exist in MPS. Instead, we just simply create the ModuleDependency in MPS like before. For details, see [lines 164-171 in ModuleTransformer](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-b9df910f37e8d8165ab9a9f7b4afa2d707f06beeac4bbbf76e1fde4a62036942R164) (where we skip the target module transformation if the module dependency is read-only), and [lines 213-220 in Module Transformer](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-b9df910f37e8d8165ab9a9f7b4afa2d707f06beeac4bbbf76e1fde4a62036942R220) (where we create the Module Dependency in MPS, just like before).

## Languages and DevKits

Languages and DevKits are not synched to the cloud, only the SimpleLanguageDependency and the DevKitDepepdency are created. Nothing changed here, even though Languages and DevKits are also read-only.

## Read-only SModels and SModules

- The [ModelSyncAction is disabled for read-only SModels](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-c9f3653533b10f19946c183f0f6fa55a51b8e55132e352050f961bd9f434a9e6R42), because we are not synching such models.
- The [ModuleSyncAction is disabled for read-only SModules](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-6a5aba4a76dadb3efcffec35ab8f920e76df77e322c035fafddaadbed453bc66R42), because we are not synching such modules.
- The [UnbindModelAction is disabled for read-only SModels](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-69addfc65398f1185d81d192e4d3880a4293d55a8f274e9bba65bc73319a8e01R42) , because we do not synch them, therefore no binding is created for them.
- The [UnbindModuleAction is disabled for read-only SModules](https://github.com/modelix/modelix.mps-plugins/pull/154/files#diff-bf67bb82e7a672063dc8e9e3a33a356c68ee72993745036449392a96f80d6900R42), because we do not synch them, therefore no binding is created for them.


# Testing

I tested the code manually in the following way:

1. I synchronized an SModule to the cloud that had an SModel with several SNodes. One of the SNode had a reference to a read-only SNode.
2. I set this reference to null and then to the original read-only SNode to see if the changes are synched to the cloud as a deletion or MPSNodeReference creation operation.
3. I put a model import in the SModel to a read-only SModel that was installed in MPS (one of the mbeddr SModels) and checked if the model import was synched to the cloud as a MPSModelImportReference.
4. I removed the aforementioned model import and checked if it was removed from the cloud.
5. I put a module dependency in the SModule to a read-only SModule that was installed in MPS (one of the mbeddr SModules) and checked if the synched Module Dependency's `isReadOnly` property was set to true.
6. I removed the aforementioned Module Dependency and checked if it was removed from the cloud.

To test the change detection from the cloud (i.e. when something changes in the cloud, then this change must also appear locally), I implemented some pieces of kotlin code in a separate intelliJ, that could do the following actions separately, when they are run:

1. Set a specific node reference to null or to a serialized MPSNodeReference. (To simulate unsetting and setting a read-only SNode reference).
2. Add / remove a read-only model import in an SModel. (To simulate adding/removing read-only model imports).
3. Add / remove a read-only module dependency in an SModule. (To simulate adding/removing read-only module dependencies).

In a separate MPS, I had the aforementioned SModule, SModel opened which was my test example. In intelliJ, I ran the aforementioned actions separately (one-by-one) and in MPS I observed in debug mode if the changes were correctly executed in the ModelixTreeChangeVisitor (that is responsible for handling changes from modelix into MPS) and the effects appeared in MPS as expected. If there was some mismatch then I fixed the code an reran the manual test scenarios until no bugs remained.

During testing, I discovered some corner-cases that I forgot to fix earlier:

- It is a bad idea to use SNode, SModel, SModules as keys in Maps, because these objects are not stable and may change at runtime without any warning. One should use SNodeReference, SModelReference, SModuleReference instead. ([8a84c5e](https://github.com/modelix/modelix.mps-plugins/pull/154/commits/8a84c5ed1a4fee60bac86b9eac98607c188e8715))
- Some convenience refactoring to expose the SRepository in the ServiceLocator. This saved some code, because we do not have to go to the MPSProject anymore to get the SRepository. ([ba8a6f3](https://github.com/modelix/modelix.mps-plugins/pull/154/commits/ba8a6f32440c3b4628b60ddfdaaed0dbe49ace40))
- I forgot to remove some elements from the cache, after the corresponding MPS elements were deleted. ([dd4218b](https://github.com/modelix/modelix.mps-plugins/pull/154/commits/dd4218b62b241abbc5523315e3d6ee0ca8c7e5d3))
- I reclassified an error to a warning, because in some cases it notifies us more about a side-effect than about a problem. I.e. when we delete a parent node, then it might be that by the deletion of the parent the children are also implicitly deleted. So when the event about the deletion of the children come from modelix, then they do not exist anymore in MPS, so it's not a problem that we could not delete them. ([4c82dd4](https://github.com/modelix/modelix.mps-plugins/pull/154/commits/4c82dd42936f2724f11091a6d9d3f597ce5b285d))

# Auxiliary information

- The merge request (MR) replaces https://github.com/modelix/modelix.mps-plugins/pull/126, that was an earlier approach for the same problem. However, the new implementation is simpler and more robust.